### PR TITLE
geko [patch] fix: skip swiftinterface cache if xcframework contains _CodeSignature

### DIFF
--- a/Sources/GekoCache/CachePipeline/Tasks/SwiftModuleCachingTask.swift
+++ b/Sources/GekoCache/CachePipeline/Tasks/SwiftModuleCachingTask.swift
@@ -90,7 +90,7 @@ public final class SwiftModuleCachingTask: CacheTask {
             destination: context.destination,
             hashedXCFrameworks: filteredHashesByXCFramework
         )
-        
+
         // Replace remaining ones
         try await replaceSwiftInterfaces(
             rootPath: context.path,
@@ -98,9 +98,9 @@ public final class SwiftModuleCachingTask: CacheTask {
             hashesByXCFrameworks: filteredHashesByXCFramework
         )
     }
-    
+
     // MARK: - Private
-    
+
     private func archive(
         graph: Graph,
         profile: ProjectDescription.Cache.Profile,
@@ -115,7 +115,7 @@ public final class SwiftModuleCachingTask: CacheTask {
                 hashedXCFrameworks: hashedXCFrameworks,
                 into: outputDirectory
             )
-            
+
             try await self.store(
                 hashedXCFrameworks: hashedXCFrameworks,
                 outputDirectory: outputDirectory,
@@ -123,7 +123,7 @@ public final class SwiftModuleCachingTask: CacheTask {
             )
         }
     }
-    
+
     private func store(
         hashedXCFrameworks: [AbsolutePath: String],
         outputDirectory: AbsolutePath,
@@ -185,6 +185,11 @@ public final class SwiftModuleCachingTask: CacheTask {
         let swiftModuleGlob = cacheProfile.platforms.isEmpty ? "*.swiftmodule" : "*{\(cacheProfile.platforms.keys.map { $0.rawValue }.joined(separator: ","))}*.swiftmodule"
         
         for (xcframeworkPath, swiftModuleFolderPath) in fetchedSwiftModules {
+            guard !xcframeworkMetadataProvider.containsCodeSignature(xcframeworkPath: xcframeworkPath) else {
+                logger.debug("Skipping swiftinterface cache for \(xcframeworkPath) because xcframework contains _CodeSignature.")
+                continue
+            }
+
             // We need path to {ModulName}.swiftmodule folder
             let swiftModules = FileHandler.shared.glob(swiftModuleFolderPath, glob: swiftModuleGlob)
             guard !swiftModules.isEmpty else {

--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -286,9 +286,12 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
         profile: ProjectDescription.Cache.Profile,
         destination: CacheFrameworkDestination
     ) throws -> XCFrameworkBuildData? {
-        guard case let .xcframework(frameworkInfo) = dependency else {
+        guard
+            case let .xcframework(frameworkInfo) = dependency
+        else {
             return nil
         }
+
         let supportedArch = profile.platforms[platform]?.arch ?? developerEnvironment.architecture.binaryArchitecture
         let dependenciesSearchPaths = transitiveDependencies.compactMap { dep -> AbsolutePath? in
             guard case let .xcframework(frameworkInfo) = dep else {

--- a/Sources/GekoCore/MetadataProviders/XCFrameworkMetadataProvider.swift
+++ b/Sources/GekoCore/MetadataProviders/XCFrameworkMetadataProvider.swift
@@ -54,6 +54,10 @@ public protocol XCFrameworkMetadataProviding: PrecompiledMetadataProviding {
     /// - Parameter xcframeworkPath: Path to the .xcframework
     /// - Parameter libraries: Framework available libraries
     func binaryPath(xcframeworkPath: AbsolutePath, libraries: [XCFrameworkInfoPlist.Library]) throws -> AbsolutePath
+
+    /// Returns true if xcframework contains `_CodeSignature` folder
+    /// - Parameter xcframeworkPath: Path to the .xcframework
+    func containsCodeSignature(xcframeworkPath: AbsolutePath) -> Bool
 }
 
 // MARK: - Default Implementation
@@ -116,6 +120,10 @@ public final class XCFrameworkMetadataProvider: PrecompiledMetadataProvider, XCF
         ])
         guard fileHandler.exists(swiftModuleFolderPath) else { return nil }
         return swiftModuleFolderPath
+    }
+
+    public func containsCodeSignature(xcframeworkPath: AbsolutePath) -> Bool {
+        return fileHandler.exists(xcframeworkPath.appending(component: "_CodeSignature"))
     }
 
     public func binaryPath(xcframeworkPath: AbsolutePath, libraries: [XCFrameworkInfoPlist.Library]) throws -> AbsolutePath {

--- a/Sources/GekoCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
+++ b/Sources/GekoCoreTesting/MetadataProviders/MockXCFrameworkMetadataProvider.swift
@@ -42,4 +42,8 @@ public final class MockXCFrameworkMetadataProvider: MockPrecompiledMetadataProvi
             return AbsolutePath.root
         }
     }
+
+    public func containsCodeSignature(xcframeworkPath: AbsolutePath) -> Bool {
+        return false
+    }
 }

--- a/Sources/GekoSupport/Process/TemporaryFile.swift
+++ b/Sources/GekoSupport/Process/TemporaryFile.swift
@@ -235,39 +235,39 @@ public func withTemporaryFile<Result>(
 /// Contains the error which can be thrown while creating a directory using POSIX's mkdir.
 public enum MakeDirectoryError: Error {
     /// The given path already exists as a directory, file or symbolic link.
-    case pathExists
+    case pathExists(String)
     /// The path provided was too long.
-    case pathTooLong
+    case pathTooLong(String)
     /// Process does not have permissions to create directory.
     /// Note: Includes read-only filesystems or if file system does not support directory creation.
-    case permissionDenied
+    case permissionDenied(String)
     /// The path provided is unresolvable because it has too many symbolic links or a path component is invalid.
-    case unresolvablePathComponent
+    case unresolvablePathComponent(String)
     /// Exceeded user quota or kernel is out of memory.
-    case outOfMemory
+    case outOfMemory(String)
     /// All other system errors with their value.
-    case other(Int32)
+    case other(Int32, String)
 }
 
 private extension MakeDirectoryError {
-    init(errno: Int32) {
+    init(errno: Int32, path: String) {
         switch errno {
         case EEXIST:
-            self = .pathExists
+            self = .pathExists(path)
         case ENAMETOOLONG:
-            self = .pathTooLong
+            self = .pathTooLong(path)
         case EACCES, EFAULT, EPERM, EROFS:
-            self = .permissionDenied
+            self = .permissionDenied(path)
         case ELOOP, ENOENT, ENOTDIR:
-            self = .unresolvablePathComponent
+            self = .unresolvablePathComponent(path)
         case ENOMEM:
-            self = .outOfMemory
+            self = .outOfMemory(path)
 #if !os(Windows)
         case EDQUOT:
-            self = .outOfMemory
+            self = .outOfMemory(path)
 #endif
         default:
-            self = .other(errno)
+            self = .other(errno, path)
         }
     }
 }
@@ -307,7 +307,7 @@ public func withTemporaryDirectory<Result>(
     var template = [UInt8](templatePath.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
 
     if mkdtemp(&template) == nil {
-        throw MakeDirectoryError(errno: errno)
+        throw MakeDirectoryError(errno: errno, path: templatePath.pathString)
     }
 
     return try body(AbsolutePath(validatingAbsolutePath: String(cString: template))) { path in
@@ -345,7 +345,7 @@ public func withTemporaryDirectory<Result>(
     var template = [UInt8](templatePath.pathString.utf8).map({ Int8($0) }) + [Int8(0)]
 
     if mkdtemp(&template) == nil {
-        throw MakeDirectoryError(errno: errno)
+        throw MakeDirectoryError(errno: errno, path: templatePath.pathString)
     }
 
     return try await body(AbsolutePath(validatingAbsolutePath: String(cString: template))) { path in

--- a/Sources/GekoSupport/Utils/TemporaryDirectory.swift
+++ b/Sources/GekoSupport/Utils/TemporaryDirectory.swift
@@ -38,7 +38,7 @@ public final class TemporaryDirectory {
         var template = [UInt8](path.pathString.utf8).map { Int8($0) } + [Int8(0)]
 
         if mkdtemp(&template) == nil {
-            throw MakeDirectoryError.other(errno)
+            throw MakeDirectoryError.other(errno, path.pathString)
         }
 
         self.path = try AbsolutePath(validatingAbsolutePath: String(cString: template))


### PR DESCRIPTION
Xcode fails to build due to framework integrity check when swiftmodule cache enabled and xcframework has _CodeSignature folder.
Skip swiftmodule cache for such xcframeworks.