### PR TITLE
geko [minor] feat: --trace option for tree command

### DIFF
--- a/Sources/GekoKit/Commands/TreeCommand.swift
+++ b/Sources/GekoKit/Commands/TreeCommand.swift
@@ -25,6 +25,9 @@ public struct TreeCommand: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Output result into a file using json format")
     var output: String? = nil
 
+    @Option(name: .shortAndLong, help: "Trace path to specified dependency. Can be specified multiple times")
+    var trace: [String] = []
+
     @OptionGroup
     var manifestOptions: ManifestOptions
 
@@ -41,6 +44,7 @@ public struct TreeCommand: AsyncParsableCommand {
 
         try await TreeService().run(
             targets: targets,
+            traceTargets: trace,
             external: external,
             usage: usage,
             minified: minified,

--- a/Sources/GekoKit/Services/TreeService.swift
+++ b/Sources/GekoKit/Services/TreeService.swift
@@ -44,6 +44,7 @@ final class TreeService {
 
     func run(
         targets: consuming [String],
+        traceTargets: consuming [String],
         external: Bool,
         usage: Bool,
         minified: Bool,
@@ -61,6 +62,10 @@ final class TreeService {
         }
         if minified {
             minimalSpanningTree(&tree)
+        }
+
+        if !traceTargets.isEmpty {
+            trace(&tree, to: traceTargets)
         }
 
         if let outputFile {
@@ -209,6 +214,30 @@ final class TreeService {
                     tree[node]!.dependencies.remove(child)
                 }
             }
+        }
+    }
+
+    private func trace(_ tree: inout [String: TreeDependency], to: [String]) {
+        func dfs(_ node: String) -> Bool {
+            var keep = false
+
+            if to.contains(node) {
+                keep = true
+            }
+
+            for dep in (tree[node]?.dependencies ?? []) {
+                if dfs(dep) {
+                    keep = true
+                } else {
+                    tree[node]?.dependencies.remove(dep)
+                }
+            }
+
+            return keep
+        }
+
+        for node in tree.keys {
+            _ = dfs(node)
         }
     }
 

--- a/docs/guides/commands/tree.md
+++ b/docs/guides/commands/tree.md
@@ -10,10 +10,11 @@ The `geko tree` command allows you to inspect dependency tree of your project.
 By default `geko tree` outputs whole project tree to stdout.
 
 **Available options**
-* `-e, --external` - dump only external dependencies.
-* `-u, --usage` - invert dependency tree and show usage of modules rather than imports.
-* `-m, --minified` - remove dependencies from tree that are available through transitive dependencies. In the other words, simply builds minimal spanning tree.
+* `-e, --external` - output only external dependencies.
+* `-u, --usage` - invert dependency tree and output usage of modules rather than imports.
+* `-m, --minified` - remove dependencies from tree that are available through transitive dependencies. In other words, builds minimal spanning tree.
 * `-o, --output <file>` - output dependency tree into a json file.
+* `-t, --trace <trace>` - output only part of dependency tree that uses specified dependency.
 
 ::: tip
 Tree command requires that external dependencies are synced with `geko fetch` before calling it.


### PR DESCRIPTION
Added ability to trace dependency usage via new --trace option of tree command. Use --trace option to output only part of dependency tree that can import specified dependency. This option can be specified multiple times.