### PR TITLE
geko [minor] feat: support plan files in generate

### DIFF
--- a/Sources/GekoKit/Commands/Cache/CacheOptions.swift
+++ b/Sources/GekoKit/Commands/Cache/CacheOptions.swift
@@ -9,7 +9,7 @@ struct CacheOptions: ParsableArguments {
     If no target is specified, all the project cacheable targets will be replaced. \
     You can use regular expressions to get the expected set of modules using quotes: 'Test.*'.\
 
-    Cannot be combined with `--plan`. \
+    Combined with entries from `--focus-plan` when both are provided. \
     If flag `--cache` wasn't passed, command will safely focus on these modules without replacing others with binary counterparts. \
     Optionally works with `--focus-tests` and `scheme`.
     """)
@@ -17,9 +17,9 @@ struct CacheOptions: ParsableArguments {
 
     @Option(
         name: .long,
-        help: "Path to a UTF-8 plan file containing one focused target name or regular expression per line. Cannot be combined with positional targets."
+        help: "Path to a UTF-8 plan file containing one focused target name or regular expression per line. Entries are combined with positional focused targets."
     )
-    var plan: String?
+    var focusPlan: String?
 
     @Option(
         name: .shortAndLong,

--- a/Sources/GekoKit/Commands/Cache/CacheOptions.swift
+++ b/Sources/GekoKit/Commands/Cache/CacheOptions.swift
@@ -9,10 +9,17 @@ struct CacheOptions: ParsableArguments {
     If no target is specified, all the project cacheable targets will be replaced. \
     You can use regular expressions to get the expected set of modules using quotes: 'Test.*'.\
 
-    If flag `--cache` wasn't passed, command will safely focus on the modules passed in the `sources` without replacing other with binary counterparts.\
+    Cannot be combined with `--plan`. \
+    If flag `--cache` wasn't passed, command will safely focus on these modules without replacing others with binary counterparts. \
     Optionally works with `--focus-tests` and `scheme`.
     """)
     var sources: [String] = []
+
+    @Option(
+        name: .long,
+        help: "Path to a UTF-8 plan file containing one focused target name or regular expression per line. Cannot be combined with positional targets."
+    )
+    var plan: String?
 
     @Option(
         name: .shortAndLong,
@@ -34,12 +41,12 @@ struct CacheOptions: ParsableArguments {
     var excludedTargets: [String] = []
 
     @Flag(
-        help: "If passed, the command doesn't cache direct internal target dependencies passed in the `--sources`, but will do it safely"
+        help: "If passed, the command doesn't cache direct internal dependencies of focused targets, but will do it safely"
     )
     var focusDirectDependencies: Bool = false
 
     @Flag(
-        help: "If passed, the command will additionaly focus on tests and apphost for passed sources targets"
+        help: "If passed, the command will additionally focus on tests and app host for focused targets"
     )
     var focusTests: Bool = false
 

--- a/Sources/GekoKit/Commands/GenerateCommand.swift
+++ b/Sources/GekoKit/Commands/GenerateCommand.swift
@@ -23,7 +23,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Flag(
         name: [.customLong("cache")],
-        help: "The command will cache all targets except those specified in sources."
+        help: "The command will cache all targets except the focused targets."
     )
     var cache: Bool = false
 
@@ -37,6 +37,11 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     var manifestOptions: ManifestOptions
 
     public func run() async throws {
+        let sources = try FocusedTargetsInputResolver().resolve(
+            sources: options.sources,
+            planPath: options.plan
+        )
+
         let path = try options.path.map {
             let resolvedPath = try AbsolutePath(validating: $0, relativeTo: .current)
             return try FileHandler.shared.resolveSymlinks(resolvedPath).pathString
@@ -62,7 +67,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
                 profile: options.profile,
                 scheme: options.scheme,
                 destination: options.destination,
-                sources: Set(options.sources),
+                sources: sources,
                 excludedTargets: Set(options.excludedTargets),
                 focusDirectDependencies: options.focusDirectDependencies,
                 focusTests: options.focusTests,
@@ -75,7 +80,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
             try await GenerateService().run(
                 path: path,
                 noOpen: options.noOpen,
-                sources: Set(options.sources),
+                sources: sources,
                 scheme: options.scheme,
                 focusTests: options.focusTests,
             )
@@ -84,7 +89,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
         GenerateCommand.analyticsDelegate?.addParameters(
             [
                 "destination": AnyCodable(options.destination),
-                "focus_targets": AnyCodable(options.sources.count),
+                "focus_targets": AnyCodable(sources.count),
                 "use_cache": AnyCodable(cache),
                 "ignore_remote_cache": AnyCodable(ignoreRemoteCache),
                 "cacheable_targets": AnyCodable(CacheAnalytics.cacheableTargets),

--- a/Sources/GekoKit/Commands/GenerateCommand.swift
+++ b/Sources/GekoKit/Commands/GenerateCommand.swift
@@ -39,7 +39,7 @@ public struct GenerateCommand: AsyncParsableCommand, HasTrackableParameters {
     public func run() async throws {
         let sources = try FocusedTargetsInputResolver().resolve(
             sources: options.sources,
-            planPath: options.plan
+            planPath: options.focusPlan
         )
 
         let path = try options.path.map {

--- a/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
+++ b/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
@@ -3,7 +3,6 @@ import GekoSupport
 import struct ProjectDescription.AbsolutePath
 
 enum FocusedTargetsInputResolverError: FatalError, Equatable {
-    case conflictingInputs
     case planNotFound(AbsolutePath)
     case planIsDirectory(AbsolutePath)
     case unableToReadPlan(AbsolutePath, reason: String)
@@ -13,8 +12,6 @@ enum FocusedTargetsInputResolverError: FatalError, Equatable {
 
     var description: String {
         switch self {
-        case .conflictingInputs:
-            return "Use either positional focused targets or --plan, not both."
         case let .planNotFound(path):
             return "The plan file was not found at \(path.pathString)."
         case let .planIsDirectory(path):
@@ -40,9 +37,6 @@ struct FocusedTargetsInputResolver {
     ) throws -> Set<String> {
         guard let planPath else {
             return Set(sources)
-        }
-        guard sources.isEmpty else {
-            throw FocusedTargetsInputResolverError.conflictingInputs
         }
 
         let path = try AbsolutePath(
@@ -72,7 +66,7 @@ struct FocusedTargetsInputResolver {
         guard !targets.isEmpty else {
             throw FocusedTargetsInputResolverError.emptyPlan(path)
         }
-        return targets
+        return targets.union(sources)
     }
 
     private func targets(from content: String) -> Set<String> {

--- a/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
+++ b/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
@@ -1,0 +1,40 @@
+import Foundation
+import GekoSupport
+import struct ProjectDescription.AbsolutePath
+
+struct FocusedTargetsInputResolver {
+    private let fileHandler: FileHandling
+
+    init(fileHandler: FileHandling = FileHandler.shared) {
+        self.fileHandler = fileHandler
+    }
+
+    func resolve(
+        sources: [String],
+        planPath: String?
+    ) throws -> Set<String> {
+        guard let planPath else {
+            return Set(sources)
+        }
+
+        let path = try AbsolutePath(
+            validating: planPath,
+            relativeTo: fileHandler.currentPath
+        )
+        let content = try fileHandler.readTextFile(path)
+        return targets(from: content)
+    }
+
+    private func targets(from content: String) -> Set<String> {
+        Set(
+            content
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter {
+                    !$0.isEmpty &&
+                        !$0.hasPrefix("#") &&
+                        !$0.hasPrefix("//")
+                }
+        )
+    }
+}

--- a/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
+++ b/Sources/GekoKit/Services/FocusedTargetsInputResolver.swift
@@ -2,6 +2,31 @@ import Foundation
 import GekoSupport
 import struct ProjectDescription.AbsolutePath
 
+enum FocusedTargetsInputResolverError: FatalError, Equatable {
+    case conflictingInputs
+    case planNotFound(AbsolutePath)
+    case planIsDirectory(AbsolutePath)
+    case unableToReadPlan(AbsolutePath, reason: String)
+    case emptyPlan(AbsolutePath)
+
+    var type: ErrorType { .abort }
+
+    var description: String {
+        switch self {
+        case .conflictingInputs:
+            return "Use either positional focused targets or --plan, not both."
+        case let .planNotFound(path):
+            return "The plan file was not found at \(path.pathString)."
+        case let .planIsDirectory(path):
+            return "Expected a plan file, but found a directory at \(path.pathString)."
+        case let .unableToReadPlan(path, reason):
+            return "Could not read the plan file at \(path.pathString): \(reason)"
+        case let .emptyPlan(path):
+            return "The plan file at \(path.pathString) does not contain any focused targets."
+        }
+    }
+}
+
 struct FocusedTargetsInputResolver {
     private let fileHandler: FileHandling
 
@@ -16,13 +41,38 @@ struct FocusedTargetsInputResolver {
         guard let planPath else {
             return Set(sources)
         }
+        guard sources.isEmpty else {
+            throw FocusedTargetsInputResolverError.conflictingInputs
+        }
 
         let path = try AbsolutePath(
             validating: planPath,
             relativeTo: fileHandler.currentPath
         )
-        let content = try fileHandler.readTextFile(path)
-        return targets(from: content)
+        guard fileHandler.exists(path) else {
+            throw FocusedTargetsInputResolverError.planNotFound(path)
+        }
+        guard !fileHandler.isFolder(path) else {
+            throw FocusedTargetsInputResolverError.planIsDirectory(path)
+        }
+
+        let content: String
+        do {
+            content = try fileHandler.readTextFile(path)
+        } catch let error as FileHandlerError {
+            throw error
+        } catch {
+            throw FocusedTargetsInputResolverError.unableToReadPlan(
+                path,
+                reason: String(describing: error)
+            )
+        }
+
+        let targets = targets(from: content)
+        guard !targets.isEmpty else {
+            throw FocusedTargetsInputResolverError.emptyPlan(path)
+        }
+        return targets
     }
 
     private func targets(from content: String) -> Set<String> {

--- a/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
@@ -3,26 +3,41 @@ import XCTest
 @testable import GekoKit
 
 final class GenerateCommandTests: XCTestCase {
-    func test_parse_acceptsPlanOption() throws {
-        let command = try GenerateCommand.parse(["--plan", "focus.plan"])
+    func test_parse_acceptsFocusPlanOption() throws {
+        let command = try GenerateCommand.parse(["--focus-plan", "focus.plan"])
 
         XCTAssertFalse(command.cache)
-        XCTAssertEqual(command.options.plan, "focus.plan")
+        XCTAssertEqual(command.options.focusPlan, "focus.plan")
         XCTAssertEqual(command.options.sources, [])
     }
 
-    func test_parse_acceptsCacheWithPlanOption() throws {
-        let command = try GenerateCommand.parse(["--cache", "--plan", "focus.plan"])
+    func test_parse_preservesPackedManifestFlagAndPathOptions() throws {
+        let command = try GenerateCommand.parse(["-fp", "FLAG", "/tmp/project"])
+
+        XCTAssertEqual(command.manifestOptions.flags, ["FLAG"])
+        XCTAssertEqual(command.options.path, "/tmp/project")
+        XCTAssertNil(command.options.focusPlan)
+    }
+
+    func test_parse_acceptsCacheWithFocusPlanOption() throws {
+        let command = try GenerateCommand.parse(["--cache", "--focus-plan", "focus.plan"])
 
         XCTAssertTrue(command.cache)
-        XCTAssertEqual(command.options.plan, "focus.plan")
+        XCTAssertEqual(command.options.focusPlan, "focus.plan")
         XCTAssertEqual(command.options.sources, [])
+    }
+
+    func test_parse_acceptsFocusPlanWithPositionalSources() throws {
+        let command = try GenerateCommand.parse(["App", "--focus-plan", "focus.plan"])
+
+        XCTAssertEqual(command.options.focusPlan, "focus.plan")
+        XCTAssertEqual(command.options.sources, ["App"])
     }
 
     func test_parse_preservesPositionalSources() throws {
         let command = try GenerateCommand.parse(["App", "Feature.*"])
 
-        XCTAssertNil(command.options.plan)
+        XCTAssertNil(command.options.focusPlan)
         XCTAssertEqual(command.options.sources, ["App", "Feature.*"])
     }
 }

--- a/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import GekoKit
+
+final class GenerateCommandTests: XCTestCase {
+    func test_parse_acceptsPlanOption() throws {
+        let command = try GenerateCommand.parse(["--plan", "focus.plan"])
+
+        XCTAssertEqual(command.options.plan, "focus.plan")
+        XCTAssertEqual(command.options.sources, [])
+    }
+
+    func test_parse_preservesPositionalSources() throws {
+        let command = try GenerateCommand.parse(["App", "Feature.*"])
+
+        XCTAssertNil(command.options.plan)
+        XCTAssertEqual(command.options.sources, ["App", "Feature.*"])
+    }
+}

--- a/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
+++ b/Tests/GekoKitTests/Commands/GenerateCommandTests.swift
@@ -6,6 +6,15 @@ final class GenerateCommandTests: XCTestCase {
     func test_parse_acceptsPlanOption() throws {
         let command = try GenerateCommand.parse(["--plan", "focus.plan"])
 
+        XCTAssertFalse(command.cache)
+        XCTAssertEqual(command.options.plan, "focus.plan")
+        XCTAssertEqual(command.options.sources, [])
+    }
+
+    func test_parse_acceptsCacheWithPlanOption() throws {
+        let command = try GenerateCommand.parse(["--cache", "--plan", "focus.plan"])
+
+        XCTAssertTrue(command.cache)
         XCTAssertEqual(command.options.plan, "focus.plan")
         XCTAssertEqual(command.options.sources, [])
     }

--- a/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
+++ b/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
@@ -55,11 +55,20 @@ final class FocusedTargetsInputResolverTests: GekoUnitTestCase {
         XCTAssertEqual(got, Set(["App"]))
     }
 
-    func test_resolve_fails_whenSourcesAndPlanAreCombined() throws {
-        XCTAssertThrowsSpecific(
-            try subject.resolve(sources: ["App"], planPath: "focus.plan"),
-            FocusedTargetsInputResolverError.conflictingInputs
+    func test_resolve_combinesPlanAndPositionalSources_andRemovesDuplicates() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        try FileHandler.shared.write(
+            "App\nFeature.*\n",
+            path: planPath,
+            atomically: true
         )
+
+        let got = try subject.resolve(
+            sources: ["App", "Extra"],
+            planPath: planPath.pathString
+        )
+
+        XCTAssertEqual(got, Set(["App", "Feature.*", "Extra"]))
     }
 
     func test_resolve_fails_whenPlanDoesNotExist() throws {
@@ -91,6 +100,20 @@ final class FocusedTargetsInputResolverTests: GekoUnitTestCase {
 
         XCTAssertThrowsSpecific(
             try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.emptyPlan(planPath)
+        )
+    }
+
+    func test_resolve_fails_whenPlanIsEmpty_evenWithPositionalSources() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        try FileHandler.shared.write(
+            "",
+            path: planPath,
+            atomically: true
+        )
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: ["App"], planPath: planPath.pathString),
             FocusedTargetsInputResolverError.emptyPlan(planPath)
         )
     }

--- a/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
+++ b/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import GekoSupport
+import XCTest
+
+@testable import GekoKit
+@testable import GekoSupportTesting
+
+final class FocusedTargetsInputResolverTests: GekoUnitTestCase {
+    private var subject: FocusedTargetsInputResolver!
+
+    override func setUp() {
+        super.setUp()
+        subject = FocusedTargetsInputResolver(fileHandler: fileHandler)
+    }
+
+    override func tearDown() {
+        subject = nil
+        super.tearDown()
+    }
+
+    func test_resolve_returnsPositionalSources_whenPlanIsNotProvided() throws {
+        let got = try subject.resolve(
+            sources: ["App", "Feature.*"],
+            planPath: nil
+        )
+
+        XCTAssertEqual(got, Set(["App", "Feature.*"]))
+    }
+
+    func test_resolve_returnsEmptySet_whenNeitherInputIsProvided() throws {
+        let got = try subject.resolve(sources: [], planPath: nil)
+
+        XCTAssertEqual(got, [])
+    }
+
+    func test_resolve_readsRelativePlan_andAppliesLineSyntax() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        let content = "# Application\r\n App \r\n\r\n// Features\r\nFeature.*\r\nApp\r\nFeature//Literal\r\nFeature#Literal\r\n"
+        try FileHandler.shared.write(content, path: planPath, atomically: true)
+
+        let got = try subject.resolve(sources: [], planPath: "focus.plan")
+
+        XCTAssertEqual(
+            got,
+            Set(["App", "Feature.*", "Feature//Literal", "Feature#Literal"])
+        )
+    }
+
+    func test_resolve_readsAbsolutePlan() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "absolute.plan")
+        try FileHandler.shared.write("App\n", path: planPath, atomically: true)
+
+        let got = try subject.resolve(sources: [], planPath: planPath.pathString)
+
+        XCTAssertEqual(got, Set(["App"]))
+    }
+}

--- a/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
+++ b/Tests/GekoKitTests/Services/FocusedTargetsInputResolverTests.swift
@@ -54,4 +54,93 @@ final class FocusedTargetsInputResolverTests: GekoUnitTestCase {
 
         XCTAssertEqual(got, Set(["App"]))
     }
+
+    func test_resolve_fails_whenSourcesAndPlanAreCombined() throws {
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: ["App"], planPath: "focus.plan"),
+            FocusedTargetsInputResolverError.conflictingInputs
+        )
+    }
+
+    func test_resolve_fails_whenPlanDoesNotExist() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "missing.plan")
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.planNotFound(planPath)
+        )
+    }
+
+    func test_resolve_fails_whenPlanIsDirectory() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        try FileHandler.shared.createFolder(planPath)
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.planIsDirectory(planPath)
+        )
+    }
+
+    func test_resolve_fails_whenPlanIsEmpty() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        try FileHandler.shared.write(
+            "",
+            path: planPath,
+            atomically: true
+        )
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.emptyPlan(planPath)
+        )
+    }
+
+    func test_resolve_fails_whenPlanContainsOnlyComments() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        try FileHandler.shared.write(
+            "\n  # comment\n  // another comment\n",
+            path: planPath,
+            atomically: true
+        )
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.emptyPlan(planPath)
+        )
+    }
+
+    func test_resolve_preservesInvalidTextEncodingError() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        fileHandler.stubExists = { $0 == planPath }
+        fileHandler.stubIsFolder = { _ in false }
+        fileHandler.stubReadTextFile = { _ in
+            throw FileHandlerError.invalidTextEncoding(planPath)
+        }
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FileHandlerError.invalidTextEncoding(planPath)
+        )
+    }
+
+    func test_resolve_wrapsUnhandledReadError() throws {
+        let planPath = FileHandler.shared.currentPath.appending(component: "focus.plan")
+        fileHandler.stubExists = { $0 == planPath }
+        fileHandler.stubIsFolder = { _ in false }
+        fileHandler.stubReadTextFile = { _ in
+            throw PlanReadTestError.unreadable
+        }
+
+        XCTAssertThrowsSpecific(
+            try subject.resolve(sources: [], planPath: planPath.pathString),
+            FocusedTargetsInputResolverError.unableToReadPlan(
+                planPath,
+                reason: "unreadable"
+            )
+        )
+    }
+}
+
+private enum PlanReadTestError: Error {
+    case unreadable
 }

--- a/docs/guides/features/cache/cache_usage.md
+++ b/docs/guides/features/cache/cache_usage.md
@@ -70,19 +70,25 @@ Feature.*
 
 Blank lines and full-line comments beginning with `#` or `//` are ignored.
 
-Use the plan for focused source generation:
+Use the plan for focused source generation with `--focus-plan`:
 
 ```bash
-geko generate --plan focus.plan
+geko generate --focus-plan focus.plan
 ```
 
 Or combine it with the cache workflow:
 
 ```bash
-geko generate --cache --plan focus.plan
+geko generate --cache --focus-plan focus.plan
 ```
 
-Relative plan paths resolve from the current working directory, independently of `--path`. A plan cannot be combined with positional focused targets, and an empty or comment-only plan is rejected.
+Positional focused targets are combined with plan entries and duplicates are removed. This lets you temporarily add another target without editing the plan:
+
+```bash
+geko generate ExtraModule --focus-plan focus.plan
+```
+
+Relative plan paths resolve from the current working directory, independently of `--path`. An explicitly provided empty or comment-only plan is rejected, including when positional focused targets are also provided.
 
 To simplify the focus, you can use the `-s, --scheme <scheme>` flag, in which case Geko will focus only on the targets specified in the scheme.
 

--- a/docs/guides/features/cache/cache_usage.md
+++ b/docs/guides/features/cache/cache_usage.md
@@ -56,6 +56,34 @@ App
 ATests ── A 
 ```
 
+## Using a focus plan
+
+When the focused target list is long or reused frequently, put one target name or regular expression on each line of a UTF-8 plan file:
+
+```text
+# Main application
+App
+
+// Current feature family
+Feature.*
+```
+
+Blank lines and full-line comments beginning with `#` or `//` are ignored.
+
+Use the plan for focused source generation:
+
+```bash
+geko generate --plan focus.plan
+```
+
+Or combine it with the cache workflow:
+
+```bash
+geko generate --cache --plan focus.plan
+```
+
+Relative plan paths resolve from the current working directory, independently of `--path`. A plan cannot be combined with positional focused targets, and an empty or comment-only plan is rejected.
+
 To simplify the focus, you can use the `-s, --scheme <scheme>` flag, in which case Geko will focus only on the targets specified in the scheme.
 
 ## Using focus tests 

--- a/docs/guides/features/cache/cache_usage.md
+++ b/docs/guides/features/cache/cache_usage.md
@@ -58,7 +58,7 @@ ATests ── A
 
 ## Using a focus plan
 
-When the focused target list is long or reused frequently, put one target name or regular expression on each line of a UTF-8 plan file:
+As a project grows, list of focused targets can become large enough to write by hand. Focus plan file can be used to pass a list of focused targets and represents a list of target names or regular expressions separated by newline. Example of focus plan can be seen below.
 
 ```text
 # Main application
@@ -68,15 +68,15 @@ App
 Feature.*
 ```
 
-Blank lines and full-line comments beginning with `#` or `//` are ignored.
+Blank lines and full-line comments starting with `#` or `//` are ignored.
 
-Use the plan for focused source generation with `--focus-plan`:
+Focus plan can be used through `--focus-plan` option:
 
 ```bash
 geko generate --focus-plan focus.plan
 ```
 
-Or combine it with the cache workflow:
+Or it can be combined with the cache workflow:
 
 ```bash
 geko generate --cache --focus-plan focus.plan
@@ -88,7 +88,7 @@ Positional focused targets are combined with plan entries and duplicates are rem
 geko generate ExtraModule --focus-plan focus.plan
 ```
 
-Relative plan paths resolve from the current working directory, independently of `--path`. An explicitly provided empty or comment-only plan is rejected, including when positional focused targets are also provided.
+Relative plan paths are resolved from the current working directory, independently of `--path`. An explicitly provided empty or comment-only plan is rejected, including when positional focused targets are also provided.
 
 To simplify the focus, you can use the `-s, --scheme <scheme>` flag, in which case Geko will focus only on the targets specified in the scheme.
 


### PR DESCRIPTION
## Description

Adds `geko generate --focus-plan <file>` for reusable focused-target lists. Plan files use UTF-8, contain one target name or regular expression per line, ignore blank lines and full-line `#` or `//` comments, and deduplicate entries.

The option works in both source-generation and cache workflows:

```bash
geko generate --focus-plan focus.plan
geko generate --cache --focus-plan focus.plan
geko generate ExtraModule --focus-plan focus.plan
```

Plan input is validated before generation, resolves relative paths from the current working directory, and does not change the meaning of `--cache`. Positional focused targets are added to plan entries, with duplicate strings removed. An explicitly supplied invalid or empty plan still fails even when positional targets are present.

## Related Issue

N/A - approved in an informal maintainer discussion.

## Motivation and Context

Long or frequently reused focused-target lists are difficult to maintain inline. A plan file makes those lists readable, reusable, and commentable without changing the existing positional workflow.

## How Has This Been Tested?

- Xcode 26.2 with the iOS 26.2 simulator runtime.
- `swift test --filter GekoKitTests`: 174 tests, 0 failures.
- `swift test`: 2,016 tests, 4 skipped, 0 failures.
- Generated `geko generate --help` inspected for `--focus-plan`, additive positional-input wording, and neutral `--cache` wording.
- SwiftLint on the three changed production files exited 0; it reported the existing `GenerateCommand.run()` function-length warning, which is also present at the merge base.
- The repository-wide lint script still exits 2 on the existing lint backlog in unrelated source and vendored files.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.