### PR TITLE
geko [minor] The 'geko test' and 'geko build' command interfaces have been extended

### DIFF
--- a/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
+++ b/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
@@ -125,9 +125,9 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: (some AsyncParsableCommand).Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         var parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -151,10 +151,10 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: EditCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--path", fixturePath.pathString,
             "--no-open",
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -175,10 +175,10 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: TestCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -189,10 +189,10 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: BuildCommand.Type, _ arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
@@ -203,10 +203,10 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     public func run(_ command: GenerateCommand.Type, arguments: [String] = []) async throws {
-        let arguments = arguments + [
+        let arguments = [
             "--no-open",
             "--path", fixturePath.pathString,
-        ]
+        ] + arguments
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()

--- a/Sources/GekoAutomation/Utilities/BuildGraphInspector.swift
+++ b/Sources/GekoAutomation/Utilities/BuildGraphInspector.swift
@@ -33,7 +33,8 @@ public protocol BuildGraphInspecting {
         testPlan: String?,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        action: XcodeBuildTestAction
     ) -> GraphTarget?
 
     /// Given a graphTraverser, it returns a list of buildable schemes.
@@ -122,7 +123,8 @@ public final class BuildGraphInspector: BuildGraphInspecting {
         testPlan: String?,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        action: XcodeBuildTestAction
     ) -> GraphTarget? {
         func isIncluded(_ testTarget: TestableTarget) -> Bool {
             if testTarget.isSkipped {
@@ -137,6 +139,14 @@ public final class BuildGraphInspector: BuildGraphInspecting {
         if let testPlanName = testPlan,
            let testPlan = scheme.testAction?.testPlans?.first(where: { $0.name == testPlanName }),
            let target = testPlan.testTargets.first(where: { isIncluded($0) })?.target
+        {
+            return graphTraverser.target(path: target.projectPath!, name: target.name)
+        } else if action == .build, let testPlans = scheme.testAction?.testPlans,
+                  let target = testPlans.flatMap(\.testTargets).first(where: { isIncluded($0) })?.target
+        {
+            return graphTraverser.target(path: target.projectPath!, name: target.name)
+        } else if let defaultTestPlan = scheme.testAction?.testPlans?.first(where: { $0.isDefault }),
+                  let target = defaultTestPlan.testTargets.first(where: { isIncluded($0) })?.target
         {
             return graphTraverser.target(path: target.projectPath!, name: target.name)
         } else if let testTarget = scheme.testAction?.targets.first {

--- a/Sources/GekoAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/GekoAutomation/Utilities/TargetBuilder.swift
@@ -100,15 +100,21 @@ public final class TargetBuilder: TargetBuilding {
             skipSigning: false
         )
 
-        let destination = try await XcodeBuildDestination.find(
-            for: target.target,
-            on: platform,
-            scheme: scheme,
-            version: osVersion,
-            deviceName: device,
-            graphTraverser: graphTraverser,
-            simulatorController: simulatorController
-        )
+        let destination: XcodeBuildDestination?
+
+        if passthroughXcodeBuildArguments.contains("-destination") {
+            destination = nil
+        } else {
+            destination = try await XcodeBuildDestination.find(
+                for: target.target,
+                on: platform,
+                scheme: scheme,
+                version: osVersion,
+                deviceName: device,
+                graphTraverser: graphTraverser,
+                simulatorController: simulatorController
+            )
+        }
 
         try xcodeBuildController
             .build(

--- a/Sources/GekoAutomation/Utilities/TargetBuilder.swift
+++ b/Sources/GekoAutomation/Utilities/TargetBuilder.swift
@@ -17,6 +17,7 @@ public protocol TargetBuilding {
     ///   - device: An optional device specifier to use when building the scheme.
     ///   - osVersion: An optional OS number to use when building the scheme.
     ///   - graphTraverser: The Graph traverser.
+    ///   - passthroughXcodeBuildArguments: The passthrough xcodebuild arguments to pass to xcodebuild
     func buildTarget(
         _ target: GraphTarget,
         platform: ProjectDescription.Platform,
@@ -29,7 +30,8 @@ public protocol TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) async throws
 }
 
@@ -86,7 +88,8 @@ public final class TargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         logger.log(level: .notice, "Building scheme \(scheme.name)", metadata: .section)
 
@@ -115,7 +118,8 @@ public final class TargetBuilder: TargetBuilding {
                 rosetta: rosetta,
                 derivedDataPath: derivedDataPath,
                 clean: clean,
-                arguments: buildArguments
+                arguments: buildArguments,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
             )
 
         if let buildOutputPath {

--- a/Sources/GekoAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/GekoAutomation/XcodeBuild/XcodeBuildController.swift
@@ -46,7 +46,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool = false,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) throws {
         var command = ["NSUnbufferedIO=YES", "/usr/bin/xcrun", "xcodebuild"]
 
@@ -64,6 +65,9 @@ public final class XcodeBuildController: XcodeBuildControlling {
 
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
+
+        // Passthrough arguments
+        command.append(contentsOf: passthroughXcodeBuildArguments)
 
         // Destination
         switch destination {
@@ -91,7 +95,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool = false,
-        destination: XcodeBuildDestination,
+        destination: XcodeBuildDestination?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
@@ -99,7 +104,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) throws {
         var command = ["NSUnbufferedIO=YES", "/usr/bin/xcrun", "xcodebuild"]
 
@@ -107,7 +113,14 @@ public final class XcodeBuildController: XcodeBuildControlling {
         if clean {
             command.append("clean")
         }
-        command.append("test")
+        switch action {
+        case .test:
+            command.append("test")
+        case .build:
+            command.append("build-for-testing")
+        case .testWithoutBuilding:
+            command.append("test-without-building")
+        }
 
         // Scheme
         command.append(contentsOf: ["-scheme", scheme])
@@ -117,6 +130,9 @@ public final class XcodeBuildController: XcodeBuildControlling {
 
         // Arguments
         command.append(contentsOf: arguments.flatMap(\.arguments))
+
+        // Passthrough arguments
+        command.append(contentsOf: passthroughXcodeBuildArguments)
 
         // Retry On Failure
         if retryCount > 0 {
@@ -133,6 +149,8 @@ public final class XcodeBuildController: XcodeBuildControlling {
             command.append(contentsOf: ["-destination", value.joined(separator: ",")])
         case .mac:
             command.append(contentsOf: ["-destination", SimulatorController().macOSDestination()])
+        case nil:
+            break
         }
 
         // Derived data path
@@ -164,7 +182,22 @@ public final class XcodeBuildController: XcodeBuildControlling {
             }
         }
 
-        return try runBuild(command: command)
+        do {
+            try runBuild(command: command)
+        } catch let error as XcodeBuildError {
+            switch error {
+            case let .buildFailed(errors, buildLogPath, rawBuildLogPath):
+                guard let xcodebuildErrorsAdditionalInfo = xcodebuildTestTargetErrorsAdditionalInfo(errors: errors) else {
+                    throw error
+                }
+
+                throw XcodeBuildError.buildFailed(
+                    errors: errors + xcodebuildErrorsAdditionalInfo,
+                    buildLogPath: buildLogPath,
+                    rawBuildLogPath: rawBuildLogPath
+                )
+            }
+        }
     }
 
     public func archive(
@@ -351,6 +384,35 @@ public final class XcodeBuildController: XcodeBuildControlling {
             timeoutTask.cancel()
             return result
         }.value
+    }
+
+    private func xcodebuildTestTargetErrorsAdditionalInfo(errors: [String]) -> [String]? {
+        if errors.contains(where: { $0.contains("There are no test bundles available to test.") }) {
+            return ["If you used a cache when generating a project, you may not have added test targets to the focus list."]
+        }
+        let targetNotFoundErrors: [String] = errors.compactMap {
+            guard let targetName = testTargetNotFoundError(text: $0.description) else { return nil }
+            return "It's possible that the test target \"\(targetName)\" was not added to the focus list when generating the project."
+        }
+        if !targetNotFoundErrors.isEmpty {
+            return targetNotFoundErrors
+        }
+        return nil
+    }
+
+    private func testTargetNotFoundError(text: String) -> String? {
+        let pattern = #"Tests in the target ["“”]([^"“”]+)["“”] can['’]t be run because ["“”]([^"“”]+)["“”] isn['’]t a member of the specified test plan or scheme"#
+        let regex = try! NSRegularExpression(pattern: pattern)
+
+        let range = NSRange(text.startIndex..., in: text)
+
+        guard let match = regex.firstMatch(in: text, range: range),
+              let targetRange = Range(match.range(at: 1), in: text)
+        else { return nil }
+
+        let targetName = String(text[targetRange])
+
+        return targetName
     }
 }
 

--- a/Sources/GekoAutomation/XcodeBuild/XcodeBuildController.swift
+++ b/Sources/GekoAutomation/XcodeBuild/XcodeBuildController.swift
@@ -67,7 +67,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         command.append(contentsOf: arguments.flatMap(\.arguments))
 
         // Passthrough arguments
-        command.append(contentsOf: passthroughXcodeBuildArguments)
+        command.append(contentsOf: passthroughXcodeBuildArguments.map { $0.spm_shellEscaped() })
 
         // Destination
         switch destination {
@@ -132,7 +132,7 @@ public final class XcodeBuildController: XcodeBuildControlling {
         command.append(contentsOf: arguments.flatMap(\.arguments))
 
         // Passthrough arguments
-        command.append(contentsOf: passthroughXcodeBuildArguments)
+        command.append(contentsOf: passthroughXcodeBuildArguments.map { $0.spm_shellEscaped() })
 
         // Retry On Failure
         if retryCount > 0 {

--- a/Sources/GekoAutomationTesting/Utilities/MockBuildGraphInspector.swift
+++ b/Sources/GekoAutomationTesting/Utilities/MockBuildGraphInspector.swift
@@ -50,16 +50,17 @@ public final class MockBuildGraphInspector: BuildGraphInspecting {
         }
     }
 
-    public var testableTargetStub: ((Scheme, String?, [TestIdentifier], [TestIdentifier], GraphTraversing) -> GraphTarget?)?
+    public var testableTargetStub: ((Scheme, String?, [TestIdentifier], [TestIdentifier], GraphTraversing, XcodeBuildTestAction) -> GraphTarget?)?
     public func testableTarget(
         scheme: Scheme,
         testPlan: String?,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        action: XcodeBuildTestAction
     ) -> GraphTarget? {
         if let testableTargetStub {
-            return testableTargetStub(scheme, testPlan, testTargets, skipTestTargets, graphTraverser)
+            return testableTargetStub(scheme, testPlan, testTargets, skipTestTargets, graphTraverser, action)
         } else {
             return GraphTarget.test()
         }

--- a/Sources/GekoAutomationTesting/Utilities/MockTargetBuilder.swift
+++ b/Sources/GekoAutomationTesting/Utilities/MockTargetBuilder.swift
@@ -17,7 +17,8 @@ public final class MockTargetBuilder: TargetBuilding {
         String?,
         Version?,
         Bool,
-        GraphTraversing
+        GraphTraversing,
+        [String]
     ) throws -> Void)?
 
     public func buildTarget(
@@ -32,7 +33,8 @@ public final class MockTargetBuilder: TargetBuilding {
         device: String?,
         osVersion: Version?,
         rosetta: Bool,
-        graphTraverser: GraphTraversing
+        graphTraverser: GraphTraversing,
+        passthroughXcodeBuildArguments: [String]
     ) throws {
         try buildTargetStub?(
             target,
@@ -45,7 +47,8 @@ public final class MockTargetBuilder: TargetBuilding {
             device,
             osVersion,
             rosetta,
-            graphTraverser
+            graphTraverser,
+            passthroughXcodeBuildArguments
         )
     }
 }

--- a/Sources/GekoCache/Utilities/Builders/CacheFrameworkBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/CacheFrameworkBuilder.swift
@@ -132,7 +132,8 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
             rosetta: false,
             derivedDataPath: derivedDataPath,
             clean: false,
-            arguments: arguments
+            arguments: arguments,
+            passthroughXcodeBuildArguments: []
         )
     }
     
@@ -153,7 +154,8 @@ public final class CacheFrameworkBuilder: CacheArtifactBuilding {
             rosetta: false,
             derivedDataPath: derivedDataPath,
             clean: false,
-            arguments: arguments
+            arguments: arguments,
+            passthroughXcodeBuildArguments: []
         )
     }
 

--- a/Sources/GekoCore/Automation/XcodeBuildControlling.swift
+++ b/Sources/GekoCore/Automation/XcodeBuildControlling.swift
@@ -7,6 +7,12 @@ public enum XcodeBuildDestination: Equatable {
     case mac
 }
 
+public enum XcodeBuildTestAction: Equatable {
+    case test
+    case build
+    case testWithoutBuilding
+}
+
 /// An enum that represents value pairs that can be passed when creating an .xcframework.
 public enum XcodeBuildControllerCreateXCFrameworkArgument {
     
@@ -113,7 +119,8 @@ public protocol XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) throws
 
     /// Returns an observable to test the given project using xcodebuild.
@@ -132,7 +139,8 @@ public protocol XcodeBuildControlling {
         _ target: XcodeBuildTarget,
         scheme: String,
         clean: Bool,
-        destination: XcodeBuildDestination,
+        destination: XcodeBuildDestination?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
@@ -140,7 +148,8 @@ public protocol XcodeBuildControlling {
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) throws
 
     /// Returns an observable that archives the given project using xcodebuild.

--- a/Sources/GekoCoreTesting/Automation/MockXcodeBuildController.swift
+++ b/Sources/GekoCoreTesting/Automation/MockXcodeBuildController.swift
@@ -12,7 +12,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         Bool,
         AbsolutePath?,
         Bool,
-        [XcodeBuildArgument]
+        [XcodeBuildArgument],
+        [String]
     ) -> [SystemEvent<XcodeBuildOutput>])?
 
     func build(
@@ -22,7 +23,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         rosetta _: Bool,
         derivedDataPath _: AbsolutePath?,
         clean _: Bool,
-        arguments _: [GekoCore.XcodeBuildArgument]
+        arguments _: [GekoCore.XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) throws {}
 
     var testStub: (
@@ -30,7 +32,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             XcodeBuildTarget,
             String,
             Bool,
-            XcodeBuildDestination,
+            XcodeBuildDestination?,
+            XcodeBuildTestAction,
             Bool,
             AbsolutePath?,
             AbsolutePath?,
@@ -38,7 +41,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
             Int,
             [TestIdentifier],
             [TestIdentifier],
-            TestPlanConfiguration?
+            TestPlanConfiguration?,
+            [String]
         )
             -> Void
     )?
@@ -47,7 +51,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         _ target: GekoCore.XcodeBuildTarget,
         scheme: String,
         clean: Bool,
-        destination: GekoCore.XcodeBuildDestination,
+        destination: GekoCore.XcodeBuildDestination?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         resultBundlePath: AbsolutePath?,
@@ -55,7 +60,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         retryCount: Int,
         testTargets: [GekoCore.TestIdentifier],
         skipTestTargets: [GekoCore.TestIdentifier],
-        testPlanConfiguration: GekoCore.TestPlanConfiguration?
+        testPlanConfiguration: GekoCore.TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) throws {
         if let testStub {
             testStub(
@@ -63,6 +69,7 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 scheme,
                 clean,
                 destination,
+                action,
                 rosetta,
                 derivedDataPath,
                 resultBundlePath,
@@ -70,7 +77,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 retryCount,
                 testTargets,
                 skipTestTargets,
-                testPlanConfiguration
+                testPlanConfiguration,
+                passthroughXcodeBuildArguments
             )
             if let testErrorStub {
                 throw testErrorStub
@@ -103,7 +111,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
         rosetta: Bool,
         derivedDataPath: AbsolutePath?,
         clean: Bool,
-        arguments: [XcodeBuildArgument]
+        arguments: [XcodeBuildArgument],
+        passthroughXcodeBuildArguments: [String]
     ) -> AsyncThrowingStream<SystemEvent<XcodeBuildOutput>, Error> {
         if let buildStub {
             return buildStub(
@@ -113,7 +122,8 @@ final class MockXcodeBuildController: XcodeBuildControlling {
                 rosetta,
                 derivedDataPath,
                 clean,
-                arguments
+                arguments,
+                passthroughXcodeBuildArguments
             ).asAsyncThrowingStream()
         } else {
             return AsyncThrowingStream {

--- a/Sources/GekoKit/Commands/BuildCommand.swift
+++ b/Sources/GekoKit/Commands/BuildCommand.swift
@@ -19,7 +19,7 @@ public struct BuildCommand: AsyncParsableCommand {
     var scheme: String?
 
     @Flag(
-        help: "Force the generation of the project before building."
+        help: "[Deprecated] Force the generation of the project before building."
     )
     var generate: Bool = false
 
@@ -72,20 +72,44 @@ public struct BuildCommand: AsyncParsableCommand {
     var buildOutputPath: String?
 
     @Option(
-        help: "Overrides the folder that should be used for derived data when building the project."
+        help: "[Deprecated] Overrides the folder that should be used for derived data when building the project."
     )
     var derivedDataPath: String?
 
     @Flag(
         name: .long,
-        help: "When passed, it generates the project and skips building. This is useful for debugging purposes."
+        help: "[Deprecated] When passed, it generates the project and skips building. This is useful for debugging purposes."
     )
     var generateOnly: Bool = false
+
+    @Argument(
+        parsing: .postTerminator,
+        help: "Arguments that will be passed through to xcodebuild"
+    )
+    var passthroughXcodeBuildArguments: [String] = []
 
     @OptionGroup
     var manifestOptions: ManifestOptions
 
+    private var notAllowedPassthroughXcodeBuildArguments = [
+        "-scheme",
+        "-workspace",
+        "-project",
+    ]
+
     public func run() async throws {
+        // Check if passthrough arguments are already handled by Geko
+        try notAllowedPassthroughXcodeBuildArguments.forEach {
+            if passthroughXcodeBuildArguments.contains($0) {
+                throw XcodeBuildPassthroughArgumentError.alreadyHandled($0)
+            }
+        }
+
+        // Suggest the user to use passthrough arguments if already supported by xcodebuild
+        if let derivedDataPath = derivedDataPath {
+            logger.warning("--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild")
+        }
+
         try ManifestOptionsService()
             .load(options: manifestOptions, path: nil)
 
@@ -108,7 +132,8 @@ public struct BuildCommand: AsyncParsableCommand {
             platform: platform,
             osVersion: os,
             rosetta: rosetta,
-            generateOnly: generateOnly
+            generateOnly: generateOnly,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Sources/GekoKit/Commands/TestCommand.swift
+++ b/Sources/GekoKit/Commands/TestCommand.swift
@@ -4,6 +4,62 @@ import struct ProjectDescription.AbsolutePath
 import GekoCore
 import GekoSupport
 
+public enum XcodeBuildPassthroughArgumentError: FatalError, Equatable {
+      case alreadyHandled(String)
+
+      public var description: String {
+          switch self {
+          case let .alreadyHandled(argument):
+              "The argument \(argument) added after the terminator (--) cannot be passed through to xcodebuild because it is handled by Geko."
+          }
+      }
+
+      public var type: ErrorType {
+          switch self {
+          case .alreadyHandled:
+              .abort
+          }
+      }
+  }
+
+enum GekoTestFlagError: FatalError, Equatable {
+      case invalidCombination([String])
+      case passthroughActionVerbConflict(String)
+
+      var description: String {
+          switch self {
+          case let .invalidCombination(arguments):
+              "The arguments \(arguments.joined(separator: ", ")) are mutually exclusive, only of them can be used."
+          case let .passthroughActionVerbConflict(verb):
+              "The xcodebuild action '\(verb)' cannot be passed after the terminator (--). 'geko test' already picks the action based on its flags: 'test' by default, 'build-for-testing' with --build-only, and 'test-without-building' with --without-building. Drop '\(verb)' from the passthrough arguments, and use --build-only or --without-building if you need a different action."
+          }
+      }
+
+      var type: ErrorType {
+          switch self {
+          case .invalidCombination, .passthroughActionVerbConflict:
+              .abort
+          }
+      }
+  }
+
+  private let notAllowedPassthroughXcodeBuildArguments = [
+      "-scheme",
+      "-workspace",
+      "-project",
+      "-testPlan",
+      "-skip-test-configuration",
+      "-only-test-configuration",
+      "-only-testing",
+      "-skip-testing",
+  ]
+
+  private let xcodeBuildActionVerbs: Set<String> = [
+      "test",
+      "build-for-testing",
+      "test-without-building",
+  ]
+
 /// Command that tests a target from the project in the current directory.
 public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     public init() {}
@@ -23,7 +79,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     var scheme: String?
 
     @Flag(
-        help: "Force the generation of the project before testing."
+        help: "[Deprecated] Force the generation of the project before testing."
     )
     var generate: Bool = false
 
@@ -82,13 +138,13 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     var resultBundlePath: String?
 
     @Option(
-        help: "Overrides the folder that should be used for derived data when testing a project."
+        help: "[Deprecated] Overrides the folder that should be used for derived data when testing a project."
     )
     var derivedDataPath: String?
 
     @Option(
         name: .long,
-        help: "Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
+        help: "[Deprecated] Tests will retry <number> of times until success. Example: if 1 is specified, the test will be retried at most once, hence it will run up to 2 times."
     )
     var retryCount: Int = 0
 
@@ -130,14 +186,37 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
 
     @Flag(
         name: .long,
-        help: "When passed, it generates the project and skips testing. This is useful for debugging purposes."
+        help: "[Deprecated] When passed, it generates the project and skips testing. This is useful for debugging purposes."
     )
     var generateOnly: Bool = false
+
+    @Flag(
+        name: .long,
+        help: "When passed, run the tests without building."
+    )
+    var withoutBuilding: Bool = false
+
+    @Flag(
+        name: .long,
+        help: "When passed, build the tests, but don't run them"
+    )
+    var buildOnly: Bool = false
+
+    @Argument(
+        parsing: .postTerminator,
+        help:
+            "Arguments that will be passed through to xcodebuild. Use -- followed by xcodebuild arguments. Example: geko test -- -destination 'platform=iOS Simulator,name=iPhone 15' -parallel-testing-enabled YES"
+    )
+    var passthroughXcodeBuildArguments: [String] = []
 
     @OptionGroup
     var manifestOptions: ManifestOptions
 
     public func validate() throws {
+        if withoutBuilding, buildOnly {
+            throw TestServiceError.actionInvalid
+        }
+
         try TestService().validateParameters(
             testTargets: testTargets,
             skipTestTargets: skipTestTargets
@@ -145,6 +224,25 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
     }
 
     public func run() async throws {
+        try notAllowedPassthroughXcodeBuildArguments.forEach {
+            if passthroughXcodeBuildArguments.contains($0) {
+                throw XcodeBuildPassthroughArgumentError.alreadyHandled($0)
+            }
+        }
+
+        if let firstPassthroughArgument = passthroughXcodeBuildArguments.first,
+           xcodeBuildActionVerbs.contains(firstPassthroughArgument)
+        {
+            throw GekoTestFlagError.passthroughActionVerbConflict(firstPassthroughArgument)
+        }
+
+        if let derivedDataPath {
+            logger.warning("--derivedDataPath is deprecated please use -derivedDataPath \(derivedDataPath) after the terminator (--) instead to passthrough parameters to xcodebuild")
+        }
+        if retryCount > 0 {
+            logger.warning("--retryCount is deprecated please use -retry-tests-on-failure -test-iterations \(retryCount + 1) after the terminator (--) instead to passthrough parameters to xcodebuild")
+        }
+
         try ManifestOptionsService()
             .load(options: manifestOptions, path: nil)
 
@@ -156,6 +254,14 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             absolutePath = FileHandler.shared.currentPath
         }
 
+        let action: XcodeBuildTestAction = if buildOnly {
+            .build
+        } else if withoutBuilding {
+            .testWithoutBuilding
+        } else {
+            .test
+        }
+
         try await TestService().run(
             schemeName: scheme,
             generate: generate,
@@ -165,6 +271,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             deviceName: device,
             platform: platform,
             osVersion: os,
+            action: action,
             rosetta: rosetta,
             skipUITests: skipUITests,
             resultBundlePath: resultBundlePath.map {
@@ -185,7 +292,8 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
                 )
             },
             validateTestTargetsParameters: false,
-            generateOnly: generateOnly
+            generateOnly: generateOnly,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Sources/GekoKit/Commands/TestCommand.swift
+++ b/Sources/GekoKit/Commands/TestCommand.swift
@@ -230,9 +230,7 @@ public struct TestCommand: AsyncParsableCommand, HasTrackableParameters {
             }
         }
 
-        if let firstPassthroughArgument = passthroughXcodeBuildArguments.first,
-           xcodeBuildActionVerbs.contains(firstPassthroughArgument)
-        {
+        if let firstPassthroughArgument = passthroughXcodeBuildArguments.first(where: { xcodeBuildActionVerbs.contains($0) }) {
             throw GekoTestFlagError.passthroughActionVerbConflict(firstPassthroughArgument)
         }
 

--- a/Sources/GekoKit/Services/BuildService.swift
+++ b/Sources/GekoKit/Services/BuildService.swift
@@ -64,7 +64,8 @@ final class BuildService {
         platform: String?,
         osVersion: String?,
         rosetta: Bool,
-        generateOnly: Bool
+        generateOnly: Bool,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         let graph: Graph
         let config = try configLoader.loadConfig(path: path)
@@ -127,7 +128,8 @@ final class BuildService {
                 device: device,
                 osVersion: osVersion?.version(),
                 rosetta: rosetta,
-                graphTraverser: graphTraverser
+                graphTraverser: graphTraverser,
+                passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
             )
         } else {
             var cleaned = false
@@ -158,7 +160,8 @@ final class BuildService {
                     device: device,
                     osVersion: osVersion?.version(),
                     rosetta: rosetta,
-                    graphTraverser: graphTraverser
+                    graphTraverser: graphTraverser,
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
                 cleaned = true
             }

--- a/Sources/GekoKit/Services/Plugin/PluginArchiveService.swift
+++ b/Sources/GekoKit/Services/Plugin/PluginArchiveService.swift
@@ -355,7 +355,8 @@ final class PluginArchiveService {
             arguments: [
                 .configuration(configuration.xcodebuildConfiguration),
                 .destination("generic/platform=macOS")
-            ]
+            ],
+            passthroughXcodeBuildArguments: []
         )
 
         let componentsToBuild = ["Build", "Products", configuration.xcodebuildConfiguration]

--- a/Sources/GekoKit/Services/RunService.swift
+++ b/Sources/GekoKit/Services/RunService.swift
@@ -118,7 +118,8 @@ final class RunService {
             device: device,
             osVersion: version?.version(),
             rosetta: rosetta,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            passthroughXcodeBuildArguments: []
         )
 
         let minVersion: Version?

--- a/Sources/GekoKit/Services/TestService.swift
+++ b/Sources/GekoKit/Services/TestService.swift
@@ -13,6 +13,7 @@ enum TestServiceError: FatalError, Equatable {
     case testIdentifierInvalid(value: String)
     case duplicatedTestTargets(Set<TestIdentifier>)
     case nothingToSkip(skipped: [TestIdentifier], included: [TestIdentifier])
+    case actionInvalid
 
     // Error description
     var description: String {
@@ -43,6 +44,8 @@ enum TestServiceError: FatalError, Equatable {
             return "The target identifier cannot be specified both in --test-targets and --skip-test-targets (were specified: \(targets.map(\.description).joined(separator: ", ")))"
         case let .nothingToSkip(skippedTargets, includedTargets):
             return "Some of the targets specified in --skip-test-targets (\(skippedTargets.map(\.description).joined(separator: ", "))) will always be skipped as they are not included in the targets specified (\(includedTargets.map(\.description).joined(separator: ", ")))"
+        case .actionInvalid:
+            return "Cannot specify both --build-only and --without-building"
         }
     }
 
@@ -50,7 +53,7 @@ enum TestServiceError: FatalError, Equatable {
     var type: ErrorType {
         switch self {
         case .schemeNotFound, .schemeWithoutTestableTargets, .testPlanNotFound, .testIdentifierInvalid, .duplicatedTestTargets,
-             .nothingToSkip:
+                .nothingToSkip, .actionInvalid:
             return .abort
         }
     }
@@ -160,6 +163,7 @@ public final class TestService { // swiftlint:disable:this type_body_length
         deviceName: String?,
         platform: String?,
         osVersion: String?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         skipUITests: Bool,
         resultBundlePath: AbsolutePath?,
@@ -170,7 +174,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
         testPlanConfiguration: TestPlanConfiguration?,
         validateTestTargetsParameters: Bool = true,
         generator: Generating? = nil,
-        generateOnly: Bool
+        generateOnly: Bool,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         if validateTestTargetsParameters {
             try validateParameters(
@@ -239,6 +244,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             }
 
             switch (testPlanConfiguration?.testPlan, scheme.testAction?.targets.isEmpty, scheme.testAction?.testPlans?.isEmpty) {
+            case (_, false, _), (_, _, false):
+                break
             case (nil, true, _), (nil, nil, _):
                 logger.log(level: .info, "The scheme \(schemeName)'s test action has no tests to run, finishing early.")
                 return
@@ -260,13 +267,15 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     version: version,
                     deviceName: deviceName,
                     platform: platform,
+                    action: action,
                     rosetta: rosetta,
                     resultBundlePath: resultBundlePath,
                     derivedDataPath: derivedDataPath,
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration,
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
             }
         } else {
@@ -289,13 +298,15 @@ public final class TestService { // swiftlint:disable:this type_body_length
                     version: version,
                     deviceName: deviceName,
                     platform: platform,
+                    action: action,
                     rosetta: rosetta,
                     resultBundlePath: resultBundlePath,
                     derivedDataPath: derivedDataPath,
                     retryCount: retryCount,
                     testTargets: testTargets,
                     skipTestTargets: skipTestTargets,
-                    testPlanConfiguration: testPlanConfiguration
+                    testPlanConfiguration: testPlanConfiguration,
+                    passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
                 )
             }
         }
@@ -314,13 +325,15 @@ public final class TestService { // swiftlint:disable:this type_body_length
         version: Version?,
         deviceName: String?,
         platform: String?,
+        action: XcodeBuildTestAction,
         rosetta: Bool,
         resultBundlePath: AbsolutePath?,
         derivedDataPath: AbsolutePath?,
         retryCount: Int,
         testTargets: [TestIdentifier],
         skipTestTargets: [TestIdentifier],
-        testPlanConfiguration: TestPlanConfiguration?
+        testPlanConfiguration: TestPlanConfiguration?,
+        passthroughXcodeBuildArguments: [String]
     ) async throws {
         logger.log(level: .notice, "Testing scheme \(scheme.name)", metadata: .section)
         if let testPlan = testPlanConfiguration?.testPlan, let testPlans = scheme.testAction?.testPlans,
@@ -337,7 +350,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             testPlan: testPlanConfiguration?.testPlan,
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: action
         ) else {
             throw TestServiceError.schemeWithoutTestableTargets(scheme: scheme.name, testPlan: testPlanConfiguration?.testPlan)
         }
@@ -350,21 +364,28 @@ public final class TestService { // swiftlint:disable:this type_body_length
             buildPlatform = try buildableTarget.target.servicePlatform
         }
 
-        let destination = try await XcodeBuildDestination.find(
-            for: buildableTarget.target,
-            on: buildPlatform,
-            scheme: scheme,
-            version: version,
-            deviceName: deviceName,
-            graphTraverser: graphTraverser,
-            simulatorController: simulatorController
-        )
+        let destination: XcodeBuildDestination?
+
+        if passthroughXcodeBuildArguments.contains("-destination") {
+            destination = nil
+        } else {
+            destination = try await XcodeBuildDestination.find(
+                for: buildableTarget.target,
+                on: buildPlatform,
+                scheme: scheme,
+                version: version,
+                deviceName: deviceName,
+                graphTraverser: graphTraverser,
+                simulatorController: simulatorController
+            )
+        }
 
         try xcodebuildController.test(
             .workspace(graphTraverser.workspace.xcWorkspacePath),
             scheme: scheme.name,
             clean: clean,
             destination: destination,
+            action: action,
             rosetta: rosetta,
             derivedDataPath: derivedDataPath,
             resultBundlePath: resultBundlePath,
@@ -377,7 +398,8 @@ public final class TestService { // swiftlint:disable:this type_body_length
             retryCount: retryCount,
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
-            testPlanConfiguration: testPlanConfiguration
+            testPlanConfiguration: testPlanConfiguration,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Tests/GekoAutomationTests/Utilities/BuildGraphInspectorTests.swift
+++ b/Tests/GekoAutomationTests/Utilities/BuildGraphInspectorTests.swift
@@ -167,7 +167,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: nil,
             testTargets: [],
             skipTestTargets: [],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -199,7 +200,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: nil,
             testTargets: [],
             skipTestTargets: [],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -245,7 +247,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: testPlan.name,
             testTargets: [],
             skipTestTargets: [],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -291,7 +294,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: testPlan.name,
             testTargets: [TestIdentifier(target: targetReference2.name)],
             skipTestTargets: [],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -337,7 +341,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: testPlan.name,
             testTargets: [],
             skipTestTargets: [TestIdentifier(target: targetReference1.name)],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -383,7 +388,8 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
             testPlan: testPlan.name,
             testTargets: [TestIdentifier(target: targetReference1.name)],
             skipTestTargets: [],
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            action: .test
         )
 
         // Then
@@ -728,5 +734,62 @@ final class BuildGraphInspectorTests: GekoUnitTestCase {
                 .test(name: "WorkspaceName-Workspace"),
             ]
         )
+    }
+
+    func test_testableTarget_withMultipleTestPlans_noneSpecified_findsTargetInNonDefaultPlan_when_action_is_build() throws {
+        // Given
+        let path = try temporaryPath()
+        let projectPath = path.appending(component: "Project.xcodeproj")
+        let target1 = Target.test(name: "Test1")
+        let targetReference1 = TargetReference(projectPath: projectPath, name: target1.name)
+        let target2 = Target.test(name: "Test2")
+        let targetReference2 = TargetReference(projectPath: projectPath, name: target2.name)
+
+        let testPlan = TestPlan(
+            path: path.appending(component: "Test.testplan"),
+            testTargets: [
+                TestableTarget(target: targetReference1, skipped: false),
+            ],
+            isDefault: true
+        )
+
+        let testPlan2 = TestPlan(
+            path: path.appending(component: "Test2.testplan"),
+            testTargets: [
+                TestableTarget(target: targetReference2, skipped: false),
+            ],
+            isDefault: false
+        )
+        let scheme = Scheme.test(
+            testAction: .test(
+                testPlans: [testPlan, testPlan2]
+            )
+        )
+        let project = Project.test(
+            path: projectPath,
+            targets: [
+                target1,
+                target2,
+            ]
+        )
+        let graph = Graph.test(
+            projects: [projectPath: project],
+            targets: [projectPath: [target1.name: target1, target2.name: target2]]
+        )
+        let graphTraverser = GraphTraverser(graph: graph)
+
+        // When
+        let got = subject.testableTarget(
+            scheme: scheme,
+            testPlan: nil,
+            testTargets: [],
+            skipTestTargets: [try TestIdentifier(target: "Test1")],
+            graphTraverser: graphTraverser,
+            action: .build
+        )
+
+        // Then
+        XCTAssertEqual(got?.project, project)
+        XCTAssertEqual(got?.target, target2)
     }
 }

--- a/Tests/GekoAutomationTests/Utilities/TargetBuilderTests.swift
+++ b/Tests/GekoAutomationTests/Utilities/TargetBuilderTests.swift
@@ -71,6 +71,7 @@ final class TargetBuilderTests: GekoUnitTestCase {
         let version = "15.2".version()
         let rosetta = true
         let device = "iPhone 13 Pro"
+        let passthroughXcodeBuildArguments = ["-test-iterations 2"]
 
         simulatorController.findAvailableDeviceStub = { _, _version, _, _deviceName in
             XCTAssertEqual(_version, version)
@@ -83,13 +84,14 @@ final class TargetBuilderTests: GekoUnitTestCase {
         }
 
         xcodeBuildController
-            .buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments in
+            .buildStub = { _workspace, _scheme, _destination, _rosetta, _, _clean, _buildArguments, _passthroughXcodeBuildArguments in
                 XCTAssertEqual(_workspace.path, workspacePath)
                 XCTAssertEqual(_scheme, scheme.name)
                 XCTAssertEqual(_destination, destination)
                 XCTAssertEqual(_rosetta, rosetta)
                 XCTAssertEqual(_clean, clean)
                 XCTAssertEqual(_buildArguments, buildArguments)
+                XCTAssertEqual(_passthroughXcodeBuildArguments, passthroughXcodeBuildArguments)
                 return [.standardOutput(.init(raw: "success"))]
             }
 
@@ -106,7 +108,8 @@ final class TargetBuilderTests: GekoUnitTestCase {
             device: device,
             osVersion: version,
             rosetta: rosetta,
-            graphTraverser: MockGraphTraverser()
+            graphTraverser: MockGraphTraverser(),
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 
@@ -118,7 +121,7 @@ final class TargetBuilderTests: GekoUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -142,7 +145,8 @@ final class TargetBuilderTests: GekoUnitTestCase {
             device: nil,
             osVersion: nil,
             rosetta: false,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            passthroughXcodeBuildArguments: []
         )
 
         // Then
@@ -169,7 +173,7 @@ final class TargetBuilderTests: GekoUnitTestCase {
         let workspacePath = try AbsolutePath(validating: "/path/to/project.xcworkspace")
         let graphTraverser = MockGraphTraverser()
 
-        xcodeBuildController.buildStub = { _, _, _, _, _, _, _ in
+        xcodeBuildController.buildStub = { _, _, _, _, _, _, _, _ in
             [.standardOutput(.init(raw: "success"))]
         }
 
@@ -193,7 +197,8 @@ final class TargetBuilderTests: GekoUnitTestCase {
             device: nil,
             osVersion: nil,
             rosetta: false,
-            graphTraverser: graphTraverser
+            graphTraverser: graphTraverser,
+            passthroughXcodeBuildArguments: []
         )
 
         // Then

--- a/Tests/GekoKitTests/Services/BuildServiceTests.swift
+++ b/Tests/GekoKitTests/Services/BuildServiceTests.swift
@@ -99,7 +99,7 @@ final class BuildServiceTests: GekoUnitTestCase {
             return buildArguments
         }
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_scheme, scheme)
                 XCTAssertTrue(_clean)
@@ -146,7 +146,7 @@ final class BuildServiceTests: GekoUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             XCTAssertEqual(_scheme, scheme)
             XCTAssertTrue(_clean)
@@ -193,7 +193,7 @@ final class BuildServiceTests: GekoUnitTestCase {
             return buildArguments
         }
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _device, _osVersion, _, _, _ in
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertNil(_device)
                 XCTAssertNil(_osVersion)
@@ -249,7 +249,7 @@ final class BuildServiceTests: GekoUnitTestCase {
             XCTAssertEqual(_skipSigning, skipSigning)
             return buildArguments
         }
-        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _ in
+        targetBuilder.buildTargetStub = { _, _workspacePath, _scheme, _clean, _, _, _, _, _, _, _, _ in
             XCTAssertEqual(_workspacePath, workspacePath)
             if _scheme.name == "A" {
                 XCTAssertEqual(_scheme, schemeA)
@@ -313,7 +313,8 @@ extension BuildService {
         platform: String? = nil,
         osVersion: String? = nil,
         rosetta: Bool = false,
-        generateOnly: Bool = false
+        generateOnly: Bool = false,
+        passthroughXcodeBuildArguments: [String] = []
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -327,7 +328,8 @@ extension BuildService {
             platform: platform,
             osVersion: osVersion,
             rosetta: rosetta,
-            generateOnly: generateOnly
+            generateOnly: generateOnly,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }

--- a/Tests/GekoKitTests/Services/RunServiceTests.swift
+++ b/Tests/GekoKitTests/Services/RunServiceTests.swift
@@ -114,7 +114,7 @@ final class RunServiceTests: GekoUnitTestCase {
         let clean = true
         let configuration = "Test"
         targetBuilder
-            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _ in
+            .buildTargetStub = { _, _workspacePath, _scheme, _clean, _configuration, _, _, _, _, _, _, _ in
                 // Then
                 XCTAssertEqual(_workspacePath, workspacePath)
                 XCTAssertEqual(_scheme.name, schemeName)
@@ -186,7 +186,7 @@ final class RunServiceTests: GekoUnitTestCase {
         buildGraphInspector.workspacePathStub = { _ in workspacePath }
         buildGraphInspector.runnableSchemesStub = { _ in [.test()] }
         buildGraphInspector.runnableTargetStub = { _, _ in .test() }
-        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
+        targetBuilder.buildTargetStub = { _, _, _, _, _, _, _, _, _, _, _, _ in expectation.fulfill() }
         targetRunner.assertCanRunTargetStub = { _ in throw TestError() }
 
         // Then

--- a/Tests/GekoKitTests/Services/TestServiceTests.swift
+++ b/Tests/GekoKitTests/Services/TestServiceTests.swift
@@ -168,24 +168,6 @@ final class TestServiceTests: GekoUnitTestCase {
         )
     }
 
-    func test_run_generates_project() async throws {
-        // Given
-        let path = try temporaryPath()
-        var generatedPath: AbsolutePath?
-        generator.generateWithGraphStub = {
-            generatedPath = $0
-            return ($0, Graph.test())
-        }
-
-        // When
-        try? await subject.testRun(
-            path: path
-        )
-
-        // Then
-        XCTAssertEqual(generatedPath, path)
-    }
-
     func test_run_tests_wtih_specified_arch() async throws {
         // Given
         buildGraphInspector.testableSchemesStub = { _ in
@@ -194,7 +176,7 @@ final class TestServiceTests: GekoUnitTestCase {
                 Scheme.test(name: "TestScheme"),
             ]
         }
-        buildGraphInspector.testableTargetStub = { scheme, _, _, _, _ in
+        buildGraphInspector.testableTargetStub = { scheme, _, _, _, _, _ in
             GraphTarget.test(
                 target: Target.test(
                     name: scheme.name
@@ -205,7 +187,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedRosetta: Bool?
-        xcodebuildController.testStub = { _, _, _, _, rosetta, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, rosetta, _, _, _, _, _, _, _, _ in
             testedRosetta = rosetta
         }
 
@@ -228,7 +210,7 @@ final class TestServiceTests: GekoUnitTestCase {
                 Scheme.test(name: "TestScheme"),
             ]
         }
-        buildGraphInspector.testableTargetStub = { scheme, _, _, _, _ in
+        buildGraphInspector.testableTargetStub = { scheme, _, _, _, _, _ in
             GraphTarget.test(
                 target: Target.test(
                     name: scheme.name
@@ -239,7 +221,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
 
@@ -270,7 +252,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
         try fileHandler.touch(
@@ -312,7 +294,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
         try fileHandler.touch(
@@ -343,7 +325,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
 
@@ -371,7 +353,7 @@ final class TestServiceTests: GekoUnitTestCase {
         }
         var testedSchemes: [String] = []
         xcodebuildController.testErrorStub = NSError.test()
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
         try fileHandler.touch(
@@ -405,7 +387,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
 
@@ -424,7 +406,7 @@ final class TestServiceTests: GekoUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
         }
         generator.generateWithGraphStub = { path in
@@ -454,7 +436,7 @@ final class TestServiceTests: GekoUnitTestCase {
         let expectedResourceBundlePath = try AbsolutePath(validating: "/test")
         var resourceBundlePath: AbsolutePath?
 
-        xcodebuildController.testStub = { _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, gotResourceBundlePath, _, _, _, _, _, _ in
             resourceBundlePath = gotResourceBundlePath
         }
         generator.generateWithGraphStub = { path in
@@ -498,7 +480,7 @@ final class TestServiceTests: GekoUnitTestCase {
         }
 
         var passedRetryCount = 0
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
         }
 
@@ -530,7 +512,7 @@ final class TestServiceTests: GekoUnitTestCase {
         }
 
         var passedRetryCount = -1
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, retryCount, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, retryCount, _, _, _, _ in
             passedRetryCount = retryCount
         }
 
@@ -560,7 +542,7 @@ final class TestServiceTests: GekoUnitTestCase {
             ]
         }
         var passedTestPlan: String?
-        buildGraphInspector.testableTargetStub = { scheme, testPlan, _, _, _ in
+        buildGraphInspector.testableTargetStub = { scheme, testPlan, _, _, _, _ in
             passedTestPlan = testPlan
             return GraphTarget.test(
                 target: Target.test(
@@ -572,7 +554,7 @@ final class TestServiceTests: GekoUnitTestCase {
             (path, Graph.test())
         }
         var testedSchemes: [String] = []
-        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, scheme, _, _, _, _, _, _, _, _, _, _, _, _ in
             testedSchemes.append(scheme)
         }
 
@@ -611,7 +593,7 @@ final class TestServiceTests: GekoUnitTestCase {
         generator.generateWithGraphStub = { path in
             (path, Graph.test())
         }
-        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _ in
+        xcodebuildController.testStub = { _, _, _, _, _, _, _, _, _, _, _, _, _, _ in
         }
 
         let notDefinedTestPlan = "NotDefined"
@@ -644,6 +626,7 @@ extension TestService {
         deviceName: String? = nil,
         platform: String? = nil,
         osVersion: String? = nil,
+        action: XcodeBuildTestAction = .test,
         rosetta: Bool = false,
         skipUiTests: Bool = false,
         resultBundlePath: AbsolutePath? = nil,
@@ -652,7 +635,8 @@ extension TestService {
         testTargets: [TestIdentifier] = [],
         skipTestTargets: [TestIdentifier] = [],
         testPlanConfiguration: TestPlanConfiguration? = nil,
-        generateOnly: Bool = false
+        generateOnly: Bool = false,
+        passthroughXcodeBuildArguments: [String] = []
     ) async throws {
         try await run(
             schemeName: schemeName,
@@ -663,6 +647,7 @@ extension TestService {
             deviceName: deviceName,
             platform: platform,
             osVersion: osVersion,
+            action: action,
             rosetta: rosetta,
             skipUITests: skipUiTests,
             resultBundlePath: resultBundlePath,
@@ -671,7 +656,8 @@ extension TestService {
             testTargets: testTargets,
             skipTestTargets: skipTestTargets,
             testPlanConfiguration: testPlanConfiguration,
-            generateOnly: generateOnly
+            generateOnly: generateOnly,
+            passthroughXcodeBuildArguments: passthroughXcodeBuildArguments
         )
     }
 }


### PR DESCRIPTION
`geko build`:
- Deprecated: `--generate`, `--derived-data-path`, `--generate-only`
- Added warnings when using deprecated command arguments
- Arguments to `xcodebuild` can now be passed after the terminator `--`. (`geko test -- -derivedDataPath somepath`)
- Added check for list of arguments that cannot be passed after the terminator `--` (`notAllowedPassthroughXcodeBuildArguments`).

`geko test`:
- Deprecated: `--generate`, `--derived-data-path`, `--generate-only`, `--retry-count`
- Added warnings when using deprecated command arguments
- Arguments to `xcodebuild` can now be passed after the terminator `--`. (`geko test -- -derivedDataPath somepath`)
- Added check for list of arguments that cannot be passed after the terminator `--` (`notAllowedPassthroughXcodeBuildArguments`).
- Added a more clear description of the error when running a test target that was not in focus during project generation (`geko generate --cache`).
- Added arguments `--without-building` and `--build-only`.
- Fixed duplicate passing of the `destination` argument if this argument was also passed after the terminator `--`.
- Fix for issue where builds were not run when building for testing but not specifying a test plan. ([BuildGraphInspector.swift](https://github.com/geko-tech/geko/pull/108/changes#diff-0c807e87073475cf264ba3eb1455e939071cd8ff5b9d370e3a8cf2e4be644cb6R144))
- Fix if no test targets are specified in the scheme, but test plans are specified. ([BuildGraphInspector.swift](https://github.com/geko-tech/geko/pull/108/changes#diff-0c807e87073475cf264ba3eb1455e939071cd8ff5b9d370e3a8cf2e4be644cb6R148))

