### PR TITLE
Geko [patch] Fix dependencies-only cache focus

### DIFF
--- a/Sources/GekoCache/Mappers/Graph/FocusedTargetsExpanderGraphMapper.swift
+++ b/Sources/GekoCache/Mappers/Graph/FocusedTargetsExpanderGraphMapper.swift
@@ -58,7 +58,6 @@ public final class FocusedTargetsExpanderGraphMapper: GraphMapping {
         graph: inout Graph,
         sideTable: inout GraphSideTable
     ) async throws -> [SideEffectDescriptor] {
-        guard !sideTable.workspace.focusedTargets.isEmpty else { return [] }
         var focusedTargets = sideTable.workspace.focusedTargets
 
         let graphTraverser = GraphTraverser(graph: graph)
@@ -71,6 +70,8 @@ public final class FocusedTargetsExpanderGraphMapper: GraphMapping {
             // If only dependencies passed then we should focus on all internal targets
             focusedTargets = Set(allInternalTargets.map(\.target.name))
         } else {
+            guard !focusedTargets.isEmpty else { return [] }
+
             if focusDirectDependencies {
                 // If skip direct dependencies passed then we should find all direct dependencies and focus them
                 let nonRunnableSourceTargets = allInternalTargets

--- a/Tests/GekoCacheTests/Mappers/Graph/FocusedTargetsExpanderGraphMapperTests.swift
+++ b/Tests/GekoCacheTests/Mappers/Graph/FocusedTargetsExpanderGraphMapperTests.swift
@@ -127,6 +127,53 @@ final class FocusedTargetsExpanderGraphMapperTests: GekoUnitTestCase {
         )
     }
 
+    func test_map_expand_when_dependencies_only_are_passed_without_sources() async throws {
+        // Given
+        let path = try temporaryPath()
+        let appPath = path.appending(component: "App")
+        let app = Target.test(name: "App", platform: .iOS, product: .app)
+        let framework = Target.test(name: "Framework", platform: .iOS, product: .staticFramework)
+        let appProject = Project.test(path: appPath, targets: [app, framework])
+
+        let externalProjectPath = path.appending(component: "External")
+        let externalFramework = Target.test(name: "ExternalFramework", platform: .iOS, product: .staticFramework)
+        let externalProject = Project.test(path: externalProjectPath, targets: [externalFramework], isExternal: true)
+
+        var graph = Graph.test(
+            name: "input",
+            workspace: .test(),
+            projects: [
+                appPath: appProject,
+                externalProjectPath: externalProject,
+            ],
+            targets: [
+                appPath: [
+                    "App": app,
+                    "Framework": framework,
+                ],
+                externalProjectPath: [
+                    "ExternalFramework": externalFramework,
+                ],
+            ]
+        )
+
+        subject = FocusedTargetsExpanderGraphMapper(
+            focusDirectDependencies: false,
+            unsafe: false,
+            dependenciesOnly: true
+        )
+
+        // When
+        var sideTable = GraphSideTable()
+        _ = try await subject.map(graph: &graph, sideTable: &sideTable)
+
+        // Then
+        XCTAssertEqual(
+            sideTable.workspace.focusedTargets.sorted(),
+            ["App", "Framework"].sorted()
+        )
+    }
+
     func test_map_expand_when_noting_are_passed() async throws {
         // Given
         //       +---->B (Framework)


### PR DESCRIPTION
## Description

Fix focus expansion when `dependenciesOnly` is enabled without explicitly specified source targets.

Previously, `FocusedTargetsExpanderGraphMapper` returned early when the focused targets set was empty. As a result, dependencies-only mode could not populate the set with all internal targets.

The early return now applies only when dependencies-only mode is disabled.

## Related Issue

No issue so far :)

## Motivation and Context

Dependencies-only caching should focus all internal targets even when no source targets are provided explicitly. The previous early return prevented this behavior and left the focused targets set empty.

## How Has This Been Tested?

Added a regression test covering dependencies-only mode without source targets.

Executed:

`swift test --filter FocusedTargetsExpanderGraphMapperTests`

All 8 selected tests passed with 0 failures.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.