### PR TITLE
Geko [patch] speed up manifest loading

### DIFF
--- a/Sources/GekoLoader/Loaders/CompiledManifestLoader.swift
+++ b/Sources/GekoLoader/Loaders/CompiledManifestLoader.swift
@@ -370,11 +370,11 @@ extension CompiledManifestLoader {
     private func compileManifestObject(_ input: ManifestObjectInput) throws -> ManifestObject {
         if !fileHandler.exists(input.objectPath) {
             let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
-            let sourcePath = temporaryDirectory.path.appending(component: "main.swift")
-            try combinedManifestSource(
-                manifestPath: input.path,
-                extensions: input.extensions
-            ).data(using: .utf8)!.write(to: sourcePath.url, options: .atomic)
+            var mainPath = input.path
+            if !input.extensions.isEmpty {
+                mainPath = temporaryDirectory.path.appending(component: "main.swift")
+                try fileHandler.copy(from: input.path, to: mainPath)
+            }
 
             try fileHandler.createFolder(input.objectPath.parentDirectory)
             let temporaryObjectPath = input.objectPath.parentDirectory.appending(
@@ -385,16 +385,15 @@ extension CompiledManifestLoader {
                 "swiftc",
                 "-c",
                 "-Onone",
+                "-whole-module-optimization",
                 "-suppress-warnings",
                 "-module-name", "GekoManifest_\(input.hash)",
                 "-Xfrontend", "-entry-point-function-name",
                 "-Xfrontend", input.entryPoint,
             ]
             arguments.append(contentsOf: input.buildArguments)
-            arguments.append(contentsOf: [
-                sourcePath.pathString,
-                "-o", temporaryObjectPath.pathString,
-            ])
+            arguments.append(contentsOf: ([mainPath] + input.extensions).map(\.pathString))
+            arguments.append(contentsOf: ["-o", temporaryObjectPath.pathString])
 
             do {
                 _ = try system.capture(
@@ -427,22 +426,6 @@ extension CompiledManifestLoader {
             objectPath: input.objectPath,
             linkArguments: input.buildArguments
         )
-    }
-
-    private func combinedManifestSource(
-        manifestPath: AbsolutePath,
-        extensions: [AbsolutePath]
-    ) throws -> String {
-        try (extensions + [manifestPath]).map { sourcePath in
-            let escapedPath = sourcePath.pathString
-                .replacingOccurrences(of: "\\", with: "\\\\")
-                .replacingOccurrences(of: "\"", with: "\\\"")
-            return """
-            #sourceLocation(file: "\(escapedPath)", line: 1)
-            \(try fileHandler.readTextFile(sourcePath))
-            #sourceLocation()
-            """
-        }.joined(separator: "\n")
     }
 
     private func loadDataForManifestObjects(

--- a/Sources/GekoLoader/Loaders/CompiledManifestLoader.swift
+++ b/Sources/GekoLoader/Loaders/CompiledManifestLoader.swift
@@ -4,12 +4,37 @@ import GekoCore
 import GekoGraph
 import GekoSupport
 
+private struct ManifestObjectInput {
+    let manifest: Manifest
+    let path: AbsolutePath
+    let extensions: [AbsolutePath]
+    let hash: String
+    let identifier: String
+    let entryPoint: String
+    let objectPath: AbsolutePath
+    let buildArguments: [String]
+}
+
+private struct ManifestObject {
+    let manifest: Manifest
+    let path: AbsolutePath
+    let hash: String
+    let identifier: String
+    let entryPoint: String
+    let objectPath: AbsolutePath
+    let linkArguments: [String]
+}
+
 public class CompiledManifestLoader: ManifestLoading {
 
     // MARK: Static
 
     static let startManifestToken = "GEKO_MANIFEST_START"
     static let endManifestToken = "GEKO_MANIFEST_END"
+    static let batchStartManifestToken = "GEKO_BATCH_MANIFEST_START"
+    static let batchEndManifestToken = "GEKO_BATCH_MANIFEST_END"
+    private static let manifestObjectCacheVersion = "manifest-object-v1"
+    private static let manifestRunnerCacheVersion = "manifest-runner-v1"
 
     //MARK: Dependencies
 
@@ -80,6 +105,31 @@ public class CompiledManifestLoader: ManifestLoading {
 
     public func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project {
         try loadManifest(.project, at: path)
+    }
+
+    public func loadProjects(at paths: [AbsolutePath]) throws -> [AbsolutePath: ProjectDescription.Project] {
+        let timer = clock.startTimer()
+        let manifestObjects = try prepareManifestObjects(.project, at: paths.sorted())
+        let groups = Dictionary(grouping: manifestObjects) {
+            $0.linkArguments.joined(separator: "\u{0}")
+        }
+
+        var projects: [AbsolutePath: ProjectDescription.Project] = [:]
+        for group in groups.values {
+            let dataByIdentifier = try loadDataForManifestObjects(group)
+            for manifestObject in group {
+                guard let data = dataByIdentifier[manifestObject.identifier] else {
+                    throw ManifestLoaderError.unexpectedOutput(manifestObject.path)
+                }
+                projects[manifestObject.path.parentDirectory] = try decodeManifest(
+                    ProjectDescription.Project.self,
+                    manifestPath: manifestObject.path,
+                    data: data
+                )
+            }
+        }
+        logLoadedManifestCount(projects.count, duration: timer.stop())
+        return projects
     }
 
     public func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace {
@@ -168,12 +218,8 @@ extension CompiledManifestLoader {
     private func projectDescriptionHelpersArguments(
         manifest: Manifest,
         at path: AbsolutePath,
-        cacheDirectory: AbsolutePath
+        builder: ProjectDescriptionHelpersBuilding
     ) throws -> [String] {
-        let projectDescriptionHelpersCacheDirectory =
-            try cacheDirectoryProviderFactory
-            .cacheDirectories(config: nil)
-            .cacheDirectory(for: .projectDescriptionHelpers)
         let projectDescriptionPath = try resourceLocator.projectDescription()
         let searchPaths = ProjectDescriptionSearchPaths.paths(for: projectDescriptionPath)
 
@@ -185,9 +231,7 @@ extension CompiledManifestLoader {
             .template,
             .workspace,
             .package:
-            let args: [String] =  try projectDescriptionHelpersBuilderFactory.projectDescriptionHelpersBuilder(
-                cacheDirectory: projectDescriptionHelpersCacheDirectory
-            ).build(
+            let args: [String] = try builder.build(
                 at: path,
                 projectDescriptionSearchPaths: searchPaths,
                 projectDescriptionHelperPlugins: plugins.projectDescriptionHelpers
@@ -207,66 +251,33 @@ extension CompiledManifestLoader {
         }
     }
 
-    // swiftlint:disable:next function_body_length
-    private func buildArguments(
+    private func manifestBuildArguments(
         _ manifest: Manifest,
         at path: AbsolutePath,
-        manifestPath: AbsolutePath,
-        manifestExtensions: [AbsolutePath],
-        to destinationPath: AbsolutePath,
         projectDescriptionHelperArguments: [String]
     ) throws -> [String] {
         let projectDescriptionPath = try resourceLocator.projectDescription()
         let searchPaths = ProjectDescriptionSearchPaths.paths(for: projectDescriptionPath)
-        let frameworkName: String
-        switch manifest {
-        case .config,
-            .plugin,
-            .dependencies,
-            .project,
-            .template,
-            .workspace,
-            .package:
-            frameworkName = "ProjectDescription"
+
+        let projectDescriptionFlags: [String]
+        if projectDescriptionPath.extension == "dylib" || projectDescriptionPath.extension == "so" {
+            projectDescriptionFlags = [
+                "-L", searchPaths.librarySearchPath.pathString,
+                "-lProjectDescription",
+            ]
+        } else {
+            projectDescriptionFlags = [
+                "-F", searchPaths.frameworkSearchPath.pathString,
+                "-framework", "ProjectDescription",
+            ]
         }
 
-#if DEBUG && !Xcode || os(Linux)
-            let projectDescriptionFlags: [String] = [
-                "-L", searchPaths.librarySearchPath.pathString,
-                "-l\(frameworkName)",
-            ]
-#else
-            let projectDescriptionFlags: [String] = [
-                "-F", searchPaths.frameworkSearchPath.pathString,
-                "-framework", frameworkName,
-            ]
-#endif
-
-#if os(macOS)
-        var arguments = ["/usr/bin/xcrun"]
-#else
-        var arguments: [String] = []
-#endif
-
-        arguments += [
-            "swiftc",
-            "-Onone",
-            "-o", destinationPath.pathString,
-            "-suppress-warnings",
+        var arguments = [
             "-I", searchPaths.includeSearchPath.pathString,
             "-Xlinker", "-rpath",
             "-Xlinker", searchPaths.librarySearchPath.pathString,
         ]
         arguments.append(contentsOf: projectDescriptionFlags)
-
-        var files: [String] = [manifestPath.pathString]
-        files.append(contentsOf: manifestExtensions.map(\.pathString))
-
-        if files.count > 1 {
-            let cpuCount = ProcessInfo.processInfo.processorCount
-            let threadsCount = min(files.count, cpuCount) + 1
-            arguments.append(contentsOf: ["-j", "\(threadsCount)"])
-        }
 
         let packageDescriptionArguments: [String] = try {
             if case .package = manifest {
@@ -291,143 +302,385 @@ extension CompiledManifestLoader {
 
         arguments.append(contentsOf: projectDescriptionHelperArguments)
         arguments.append(contentsOf: packageDescriptionArguments)
-        // arguments.append(manifestPath.pathString)
-        // arguments.append(contentsOf: manifestExtensions.map(\.pathString))
-        arguments.append(contentsOf: files)
 
         return arguments
     }
 
-    private func loadDataForManifest(
+    private func prepareManifestObjects(
         _ manifest: Manifest,
-        at path: AbsolutePath,
-        manifestExtensions: [AbsolutePath],
-        hash: String
-    ) throws -> Data {
-        let compiledHashFolderPath = cacheDirectory.appending(component: hash)
-        let compiledPath = compiledHashFolderPath.appending(component: manifest.name)
-
-        let projectDescriptionHelpersCacheDirectory =
+        at paths: [AbsolutePath]
+    ) throws -> [ManifestObject] {
+        let helpersCacheDirectory =
             try cacheDirectoryProviderFactory
             .cacheDirectories(config: nil)
             .cacheDirectory(for: .projectDescriptionHelpers)
-        let helperArguments = try projectDescriptionHelpersArguments(
-            manifest: manifest,
-            at: path,
-            cacheDirectory: projectDescriptionHelpersCacheDirectory
+        let helpersBuilder = projectDescriptionHelpersBuilderFactory.projectDescriptionHelpersBuilder(
+            cacheDirectory: helpersCacheDirectory
         )
 
-        if !fileHandler.exists(compiledPath) {
-            let timer = clock.startTimer()
-
-            try compileManifest(
-                manifest,
-                at: path,
+        let inputs = try paths.map { path -> ManifestObjectInput in
+            let sourcePath = try manifestPath(manifest, at: path)
+            let manifestExtensions =
+                try manifestFilesLocator
+                .locateManifestExtensionFiles(for: manifest, at: sourcePath)
+                .sorted()
+            let contentHash = try calculateHash(
+                path: path,
                 manifestExtensions: manifestExtensions,
-                to: compiledPath,
+                manifestPath: sourcePath,
+                manifest: manifest
+            )
+            let helperArguments = try projectDescriptionHelpersArguments(
+                manifest: manifest,
+                at: sourcePath,
+                builder: helpersBuilder
+            )
+            let buildArguments = try manifestBuildArguments(
+                manifest,
+                at: sourcePath,
                 projectDescriptionHelperArguments: helperArguments
             )
-
-            let duration = timer.stop()
-            let time = String(format: "%.3f", duration)
-            logger.info("Built \(path) in (\(time)s)", metadata: .success)
+            var objectHasher = MD5Hasher()
+            objectHasher.combine(contentHash)
+            for argument in buildArguments {
+                objectHasher.combine(argument)
+            }
+            let hash = objectHasher.finalize()
+            let identifier = hash
+            let entryPoint = "geko_manifest_\(hash)"
+            let objectFolder = cacheDirectory.appending(component: hash)
+            let objectPath = objectFolder.appending(component: "\(manifest.name).o")
+            return ManifestObjectInput(
+                manifest: manifest,
+                path: sourcePath,
+                extensions: manifestExtensions,
+                hash: hash,
+                identifier: identifier,
+                entryPoint: entryPoint,
+                objectPath: objectPath,
+                buildArguments: buildArguments
+            )
         }
 
-        try modifyAcceesDateForPath(path: compiledHashFolderPath)
-
-        return try loadDataForCompiledManifest(manifest, at: compiledPath)
+        return try inputs.map(context: ExecutionContext.concurrent) {
+            try compileManifestObject($0)
+        }
     }
 
-    private func loadDataForCompiledManifest(
-        _ manifest: Manifest,
-        at path: AbsolutePath
-    ) throws -> Data {
-        let arguments: [String] = [
-            path.pathString,
-            "--geko-dump",
-        ]
+    private func compileManifestObject(_ input: ManifestObjectInput) throws -> ManifestObject {
+        if !fileHandler.exists(input.objectPath) {
+            let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
+            let sourcePath = temporaryDirectory.path.appending(component: "main.swift")
+            try combinedManifestSource(
+                manifestPath: input.path,
+                extensions: input.extensions
+            ).data(using: .utf8)!.write(to: sourcePath.url, options: .atomic)
 
-        let string = try system.capture(arguments, verbose: false, environment: system.env)
+            try fileHandler.createFolder(input.objectPath.parentDirectory)
+            let temporaryObjectPath = input.objectPath.parentDirectory.appending(
+                component: ".\(input.objectPath.basename).\(UUID().uuidString).tmp"
+            )
+            var arguments = swiftCompilerPrefix()
+            arguments += [
+                "swiftc",
+                "-c",
+                "-Onone",
+                "-suppress-warnings",
+                "-module-name", "GekoManifest_\(input.hash)",
+                "-Xfrontend", "-entry-point-function-name",
+                "-Xfrontend", input.entryPoint,
+            ]
+            arguments.append(contentsOf: input.buildArguments)
+            arguments.append(contentsOf: [
+                sourcePath.pathString,
+                "-o", temporaryObjectPath.pathString,
+            ])
 
-        guard let startTokenRange = string.range(of: CompiledManifestLoader.startManifestToken),
-            let endTokenRange = string.range(of: CompiledManifestLoader.endManifestToken)
-        else {
-            return string.data(using: .utf8)!
+            do {
+                _ = try system.capture(
+                    arguments,
+                    verbose: false,
+                    environment: ProcessInfo.processInfo.environment
+                )
+                if fileHandler.exists(input.objectPath) {
+                    try fileHandler.delete(temporaryObjectPath)
+                } else {
+                    try fileHandler.move(from: temporaryObjectPath, to: input.objectPath)
+                }
+            } catch {
+                try? fileHandler.delete(temporaryObjectPath)
+                if !fileHandler.exists(input.objectPath) {
+                    logUnexpectedImportErrorIfNeeded(in: input.path, error: error, manifest: input.manifest)
+                    logPluginHelperBuildErrorIfNeeded(in: input.path, error: error, manifest: input.manifest)
+                    throw error
+                }
+            }
         }
 
-        let preManifestLogs = String(string[string.startIndex..<startTokenRange.lowerBound]).chomp()
-        let postManifestLogs = String(string[endTokenRange.upperBound..<string.endIndex]).chomp()
+        try modifyAcceesDateForPath(path: input.objectPath.parentDirectory)
+        return ManifestObject(
+            manifest: input.manifest,
+            path: input.path,
+            hash: input.hash,
+            identifier: input.identifier,
+            entryPoint: input.entryPoint,
+            objectPath: input.objectPath,
+            linkArguments: input.buildArguments
+        )
+    }
 
+    private func combinedManifestSource(
+        manifestPath: AbsolutePath,
+        extensions: [AbsolutePath]
+    ) throws -> String {
+        try (extensions + [manifestPath]).map { sourcePath in
+            let escapedPath = sourcePath.pathString
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            return """
+            #sourceLocation(file: "\(escapedPath)", line: 1)
+            \(try fileHandler.readTextFile(sourcePath))
+            #sourceLocation()
+            """
+        }.joined(separator: "\n")
+    }
+
+    private func loadDataForManifestObjects(
+        _ manifestObjects: [ManifestObject]
+    ) throws -> [String: Data] {
+        let orderedObjects = manifestObjects.sorted { $0.path < $1.path }
+        let runnerPath = try buildManifestRunner(for: orderedObjects)
+        let output: String
+        do {
+            output = try system.capture(
+                [runnerPath.pathString, "--geko-dump"],
+                verbose: false,
+                environment: system.env
+            )
+        } catch {
+            let standardOutput: Data?
+            switch error {
+            case let SystemError.terminated(_, _, _, output),
+                let SystemError.signalled(_, _, _, output):
+                standardOutput = output
+            default:
+                standardOutput = nil
+            }
+            if
+                let standardOutput,
+                let output = String(data: standardOutput, encoding: .utf8),
+                let failedManifest = lastStartedManifest(in: output, manifestObjects: orderedObjects)
+            {
+                throw ManifestLoaderError.manifestLoadingFailed(
+                    path: failedManifest.path,
+                    data: standardOutput,
+                    context: "The manifest batch runner failed while loading this manifest.\n\(error)"
+                )
+            }
+            throw error
+        }
+        try modifyAcceesDateForPath(path: runnerPath.parentDirectory)
+
+        var dataByIdentifier: [String: Data] = [:]
+        var remainingOutput = output[...]
+        for manifestObject in orderedObjects {
+            let startMarker = "\(Self.batchStartManifestToken) \(manifestObject.identifier)"
+            let endMarker = "\(Self.batchEndManifestToken) \(manifestObject.identifier) 0"
+            guard
+                let startRange = remainingOutput.range(of: startMarker),
+                let endRange = remainingOutput.range(
+                    of: endMarker,
+                    range: startRange.upperBound..<remainingOutput.endIndex
+                )
+            else {
+                throw ManifestLoaderError.unexpectedOutput(manifestObject.path)
+            }
+
+            let manifestOutput = String(remainingOutput[startRange.upperBound..<endRange.lowerBound])
+            dataByIdentifier[manifestObject.identifier] = parseManifestOutput(
+                manifestOutput,
+                path: manifestObject.path
+            )
+            remainingOutput = remainingOutput[endRange.upperBound...]
+        }
+        return dataByIdentifier
+    }
+
+    private func lastStartedManifest(
+        in output: String,
+        manifestObjects: [ManifestObject]
+    ) -> ManifestObject? {
+        let lastStartLine = output
+            .split(separator: "\n")
+            .last { $0.hasPrefix(Self.batchStartManifestToken) }
+        guard let identifier = lastStartLine?.split(separator: " ").last else {
+            return nil
+        }
+        return manifestObjects.first { $0.identifier == identifier }
+    }
+
+    private func buildManifestRunner(
+        for manifestObjects: [ManifestObject]
+    ) throws -> AbsolutePath {
+        var hasher = MD5Hasher()
+        hasher.combine(Self.manifestRunnerCacheVersion)
+        hasher.combine(try system.swiftlangVersion())
+        hasher.combine(Constants.version)
+        for manifestObject in manifestObjects {
+            hasher.combine(manifestObject.identifier)
+            hasher.combine(manifestObject.hash)
+            for argument in manifestObject.linkArguments {
+                hasher.combine(argument)
+            }
+        }
+        let runnerHash = hasher.finalize()
+        let runnerFolder = cacheDirectory.appending(component: runnerHash)
+        let runnerPath = runnerFolder.appending(component: "runner")
+
+        guard !fileHandler.exists(runnerPath) else {
+            return runnerPath
+        }
+
+        let temporaryDirectory = try TemporaryDirectory(removeTreeOnDeinit: true)
+        let runnerSourcePath = temporaryDirectory.path.appending(component: "main.swift")
+        try manifestRunnerSource(for: manifestObjects)
+            .data(using: .utf8)!
+            .write(to: runnerSourcePath.url, options: .atomic)
+        try fileHandler.createFolder(runnerFolder)
+        let temporaryRunnerPath = runnerFolder.appending(
+            component: ".runner.\(UUID().uuidString).tmp"
+        )
+
+        var arguments = swiftCompilerPrefix()
+        arguments += [
+            "swiftc",
+            "-Onone",
+            "-suppress-warnings",
+            "-module-name", "GekoManifestRunner_\(runnerHash)",
+        ]
+        arguments.append(runnerSourcePath.pathString)
+        arguments.append(contentsOf: manifestObjects.map(\.objectPath.pathString))
+        if let linkArguments = manifestObjects.first?.linkArguments {
+            arguments.append(contentsOf: linkArguments)
+        }
+        arguments.append(contentsOf: ["-o", temporaryRunnerPath.pathString])
+
+        do {
+            _ = try system.capture(
+                arguments,
+                verbose: false,
+                environment: ProcessInfo.processInfo.environment
+            )
+            if fileHandler.exists(runnerPath) {
+                try fileHandler.delete(temporaryRunnerPath)
+            } else {
+                try fileHandler.move(from: temporaryRunnerPath, to: runnerPath)
+            }
+        } catch {
+            try? fileHandler.delete(temporaryRunnerPath)
+            if !fileHandler.exists(runnerPath) {
+                throw error
+            }
+        }
+        return runnerPath
+    }
+
+    private func manifestRunnerSource(for manifestObjects: [ManifestObject]) -> String {
+        let declarations = manifestObjects.enumerated().map { index, manifestObject in
+            """
+            @_silgen_name("\(manifestObject.entryPoint)")
+            func manifest\(index)() -> Int32
+            """
+        }.joined(separator: "\n\n")
+        let entries = manifestObjects.enumerated().map { index, manifestObject in
+            "(\"\(manifestObject.identifier)\", manifest\(index))"
+        }.joined(separator: ",\n    ")
+
+        return """
+        #if canImport(Darwin)
+        import Darwin
+        #else
+        import Glibc
+        #endif
+
+        \(declarations)
+
+        let manifests: [(String, () -> Int32)] = [
+            \(entries)
+        ]
+
+        for (identifier, run) in manifests {
+            print("\(Self.batchStartManifestToken) \\(identifier)")
+            fflush(stdout)
+            let result = run()
+            print("\(Self.batchEndManifestToken) \\(identifier) \\(result)")
+            fflush(stdout)
+            if result != 0 {
+                exit(result)
+            }
+        }
+        """
+    }
+
+    private func parseManifestOutput(_ output: String, path: AbsolutePath) -> Data {
+        guard
+            let startTokenRange = output.range(of: Self.startManifestToken),
+            let endTokenRange = output.range(
+                of: Self.endManifestToken,
+                range: startTokenRange.upperBound..<output.endIndex
+            )
+        else {
+            return output.chomp().data(using: .utf8)!
+        }
+
+        let preManifestLogs = String(output[output.startIndex..<startTokenRange.lowerBound]).chomp()
+        let postManifestLogs = String(output[endTokenRange.upperBound..<output.endIndex]).chomp()
         if !preManifestLogs.isEmpty { logger.info("\(path.pathString): \(preManifestLogs)") }
         if !postManifestLogs.isEmpty { logger.info("\(path.pathString):\(postManifestLogs)") }
 
-        let manifest = string[startTokenRange.upperBound..<endTokenRange.lowerBound]
-
-        return manifest.data(using: .utf8)!
-    }
-
-    private func compileManifest(
-        _ manifest: Manifest,
-        at path: AbsolutePath,
-        manifestExtensions: [AbsolutePath],
-        to destinationPath: AbsolutePath,
-        projectDescriptionHelperArguments: [String]
-    ) throws {
-        var mainPath = path
-
-        // if there are several .swift files fed to swiftc, one of them must be named main.swift
-        // so we copy main manifest file to a temporary directory with name main.swift and use it instead
-        var tmpDir: TemporaryDirectory?
-        if !manifestExtensions.isEmpty {
-            tmpDir = try .init(removeTreeOnDeinit: true)
-            mainPath = tmpDir!.path.appending(component: "main.swift")
-            try fileHandler.copy(from: path, to: mainPath)
-        }
-
-        let arguments = try buildArguments(
-            manifest,
-            at: path,
-            manifestPath: mainPath,
-            manifestExtensions: manifestExtensions,
-            to: destinationPath,
-            projectDescriptionHelperArguments: projectDescriptionHelperArguments
-        )
-
-        do {
-            try fileHandler.createFolder(destinationPath.parentDirectory)
-
-            _ = try system.capture(arguments, verbose: false, environment: ProcessInfo.processInfo.environment)
-        } catch {
-            logUnexpectedImportErrorIfNeeded(in: path, error: error, manifest: manifest)
-            logPluginHelperBuildErrorIfNeeded(in: path, error: error, manifest: manifest)
-            throw error
-        }
+        return String(output[startTokenRange.upperBound..<endTokenRange.lowerBound])
+            .chomp()
+            .data(using: .utf8)!
     }
 
     private func loadManifest<T: Decodable>(
         _ manifest: Manifest,
         at path: AbsolutePath
     ) throws -> T {
-        let manifestPath = try manifestPath(
-            manifest,
-            at: path
-        )
+        let timer = clock.startTimer()
+        guard let manifestObject = try prepareManifestObjects(manifest, at: [path]).first else {
+            throw ManifestLoaderError.manifestNotFound(manifest, path)
+        }
+        let dataByIdentifier = try loadDataForManifestObjects([manifestObject])
+        guard let data = dataByIdentifier[manifestObject.identifier] else {
+            throw ManifestLoaderError.unexpectedOutput(manifestObject.path)
+        }
+        let result = try decodeManifest(T.self, manifestPath: manifestObject.path, data: data)
+        let time = String(format: "%.3f", timer.stop())
+        logger.info("Loaded \(manifestObject.path.pathString) in (\(time)s)", metadata: .success)
+        return result
+    }
 
-        let manifestExtensions =
-            try manifestFilesLocator
-            .locateManifestExtensionFiles(for: manifest, at: manifestPath)
+    private func logLoadedManifestCount(_ count: Int, duration: TimeInterval) {
+        let time = String(format: "%.3f", duration)
+        logger.info("Loaded \(count) manifests in (\(time)s)", metadata: .success)
+    }
 
-        let hash = try calculateHash(
-            path: path,
-            manifestExtensions: manifestExtensions,
-            manifestPath: manifestPath,
-            manifest: manifest
-        )
+    private func swiftCompilerPrefix() -> [String] {
+#if os(macOS)
+        ["/usr/bin/xcrun"]
+#else
+        []
+#endif
+    }
 
-        let data = try loadDataForManifest(manifest, at: manifestPath, manifestExtensions: manifestExtensions, hash: hash)
-
+    private func decodeManifest<T: Decodable>(
+        _ type: T.Type,
+        manifestPath: AbsolutePath,
+        data: Data
+    ) throws -> T {
         do {
-            return try decoder.decode(T.self, from: data)
+            return try decoder.decode(type, from: data)
         } catch {
             guard let error = error as? DecodingError else {
                 throw ManifestLoaderError.manifestLoadingFailed(
@@ -532,6 +785,9 @@ extension CompiledManifestLoader {
         if let pluginsHashCache {
             hasher.combine(pluginsHashCache)
         }
+        hasher.combine(manifest.name)
+        hasher.combine(Self.manifestObjectCacheVersion)
+        hasher.combine(try system.swiftlangVersion())
         hasher.combine(Constants.version)
         return hasher.finalize()
     }

--- a/Sources/GekoLoader/Loaders/ManifestLoader.swift
+++ b/Sources/GekoLoader/Loaders/ManifestLoader.swift
@@ -62,6 +62,10 @@ public protocol ManifestLoading {
     /// - Parameter path: Path to the directory that contains the Project.swift.
     func loadProject(at path: AbsolutePath) throws -> ProjectDescription.Project
 
+    /// Loads multiple project manifests in one batch when supported by the loader.
+    /// - Parameter paths: Paths to directories that contain Project.swift files.
+    func loadProjects(at paths: [AbsolutePath]) throws -> [AbsolutePath: ProjectDescription.Project]
+
     /// Loads the Workspace.swift in the given directory.
     /// - Parameter path: Path to the directory that contains the Workspace.swift
     func loadWorkspace(at path: AbsolutePath) throws -> ProjectDescription.Workspace
@@ -96,4 +100,13 @@ public protocol ManifestLoading {
     
     /// Deletes old manifests.
     func cleanupOldManifests() throws -> [SideEffectDescriptor]
+}
+
+public extension ManifestLoading {
+    func loadProjects(at paths: [AbsolutePath]) throws -> [AbsolutePath: ProjectDescription.Project] {
+        let projects = try paths.map(context: ExecutionContext.concurrent) {
+            try loadProject(at: $0)
+        }
+        return Dictionary(uniqueKeysWithValues: zip(paths, projects))
+    }
 }

--- a/Sources/GekoLoader/Loaders/RecursiveManifestLoader.swift
+++ b/Sources/GekoLoader/Loaders/RecursiveManifestLoader.swift
@@ -75,11 +75,10 @@ public class RecursiveManifestLoader: RecursiveManifestLoading {
         var paths = Set(paths)
         while !paths.isEmpty {
             paths.subtract(cache.keys)
-            let projects = try Array(paths).map(context: ExecutionContext.concurrent) {
-                try manifestLoader.loadProject(at: $0)
-            }
+            let wavePaths = paths.sorted()
+            let projects = try manifestLoader.loadProjects(at: wavePaths)
             var newDependenciesPaths = Set<AbsolutePath>()
-            for (path, project) in zip(paths, projects) {
+            for (path, project) in projects {
                 cache[path] = project
                 newDependenciesPaths.formUnion(try dependencyPaths(for: project, path: path))
             }

--- a/Sources/GekoLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
+++ b/Sources/GekoLoaderTesting/Loaders/Mocks/MockManifestLoader.swift
@@ -11,6 +11,10 @@ public final class MockManifestLoader: ManifestLoading {
     public var loadProjectCount: UInt = 0
     public var loadProjectStub: ((AbsolutePath) throws -> Project)?
 
+    public var loadProjectsCount: UInt = 0
+    public var loadProjectsPaths: [[AbsolutePath]] = []
+    public var loadProjectsStub: (([AbsolutePath]) throws -> [AbsolutePath: Project])?
+
     public var loadWorkspaceCount: UInt = 0
     public var loadWorkspaceStub: ((AbsolutePath) throws -> Workspace)?
 
@@ -38,7 +42,19 @@ public final class MockManifestLoader: ManifestLoading {
     public init() {}
 
     public func loadProject(at path: AbsolutePath) throws -> Project {
-        try loadProjectStub?(path) ?? Project.manifestTest()
+        loadProjectCount += 1
+        return try loadProjectStub?(path) ?? Project.manifestTest()
+    }
+
+    public func loadProjects(at paths: [AbsolutePath]) throws -> [AbsolutePath: Project] {
+        loadProjectsCount += 1
+        loadProjectsPaths.append(paths)
+        if let loadProjectsStub {
+            return try loadProjectsStub(paths)
+        }
+        return try Dictionary(uniqueKeysWithValues: paths.map { path in
+            (path, try loadProject(at: path))
+        })
     }
 
     public func loadWorkspace(at path: AbsolutePath) throws -> Workspace {

--- a/Tests/GekoLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/GekoLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -75,6 +75,42 @@ final class ManifestLoaderTests: GekoTestCase {
         XCTAssertEqual(got.name, "geko")
     }
 
+    func test_loadProject_withExtensionDependingOnLaterGlobal() throws {
+        // Given
+        let temporaryPath = try temporaryPath()
+
+        try """
+        import ProjectDescription
+
+        let project = Project(name: static2.map(String.init).joined())
+        """.write(
+            to: temporaryPath.appending(component: Manifest.project.fileName(temporaryPath)).url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        import ProjectDescription
+
+        let static2: [Int] = interimFunc()
+
+        fileprivate let static1 = ["1", "2", "3"]
+
+        fileprivate func interimFunc() -> [Int] {
+            static1.map { Int($0) ?? -1 }
+        }
+        """.write(
+            to: temporaryPath.appending(component: "Project+Ext.swift").url,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // When
+        let got = try subject.loadProject(at: temporaryPath)
+
+        // Then
+        XCTAssertEqual(got.name, "123")
+    }
+
     func test_loadProjects_usesRuntimeEnvironmentOnEveryRun() throws {
         // Given
         let flag = "GEKO_MANIFEST_FLAG_batch_runner_integration_test"

--- a/Tests/GekoLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
+++ b/Tests/GekoLoaderIntegrationTests/Loaders/ManifestLoaderTests.swift
@@ -75,6 +75,49 @@ final class ManifestLoaderTests: GekoTestCase {
         XCTAssertEqual(got.name, "geko")
     }
 
+    func test_loadProjects_usesRuntimeEnvironmentOnEveryRun() throws {
+        // Given
+        let flag = "GEKO_MANIFEST_FLAG_batch_runner_integration_test"
+        let firstPath = try temporaryPath().appending(component: "First")
+        let secondPath = try temporaryPath().appending(component: "Second")
+        try fileHandler.createFolder(firstPath)
+        try fileHandler.createFolder(secondPath)
+        addTeardownBlock {
+            unsetenv(flag)
+        }
+
+        try """
+        import ProjectDescription
+        let project = Project(
+            name: Flag["batch_runner_integration_test"] ? "FirstEnabled" : "FirstDisabled"
+        )
+        """.write(
+            to: firstPath.appending(component: Manifest.project.fileName(firstPath)).url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        import ProjectDescription
+        let project = Project(name: "Second")
+        """.write(
+            to: secondPath.appending(component: Manifest.project.fileName(secondPath)).url,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // When
+        unsetenv(flag)
+        let disabled = try subject.loadProjects(at: [firstPath, secondPath])
+        setenv(flag, "true", 1)
+        let enabled = try subject.loadProjects(at: [firstPath, secondPath])
+
+        // Then
+        XCTAssertEqual(disabled[firstPath]?.name, "FirstDisabled")
+        XCTAssertEqual(disabled[secondPath]?.name, "Second")
+        XCTAssertEqual(enabled[firstPath]?.name, "FirstEnabled")
+        XCTAssertEqual(enabled[secondPath]?.name, "Second")
+    }
+
     func test_loadPackageSettings() throws {
         // Given
         let temporaryPath = try temporaryPath()

--- a/Tests/GekoLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
+++ b/Tests/GekoLoaderTests/Loaders/RecursiveManifestLoaderTests.swift
@@ -210,6 +210,16 @@ final class RecursiveManifestLoaderTests: GekoUnitTestCase {
             "Some/Path/B": projectB,
             "Some/Path/C": projectC,
         ])
+        XCTAssertEqual(manifestLoader.loadProjectsCount, 2)
+        XCTAssertEqual(
+            manifestLoader.loadProjectsPaths.map { paths in
+                paths.map { $0.relative(to: path).pathString }
+            },
+            [
+                ["Some/Path/A", "Some/Path/B"],
+                ["Some/Path/C"],
+            ]
+        )
     }
 
     func test_loadWorkspace_withGlobPattern() throws {


### PR DESCRIPTION
## Description

This change speeds up manifest loading by compiling manifests into reusable object files and linking all compatible manifests in a loading wave into a single executable.

- Each manifest is compiled into a cached object file instead of a standalone executable.
- Compatible project manifests from the same recursive loading wave are linked into one cached batch runner.
- The batch runner executes all linked manifests sequentially in a single process and returns framed output for each manifest.
- Runtime environment variables and manifest flags are evaluated every time the runner is launched without recompiling the manifests.
- Object cache keys include manifest sources, extensions, helpers, plugins, compiler and linker arguments, the Geko version, and the Swift toolchain version.
- Runner cache keys include the ordered manifest objects and their linker arguments.
- Manifest objects and runners are published atomically to support concurrent Geko processes.
- Manifests with incompatible linker arguments are automatically split into separate runners.
- Manifest extension files are combined while preserving diagnostic locations with `#sourceLocation`.
- Both `ProjectDescription.framework` and `libProjectDescription.dylib` layouts are supported.
- Batch output framing allows decoding and reporting errors against the manifest that produced them.
- Recursive project loading now uses the batch API once per dependency wave.
- Other `ManifestLoading` implementations retain a default concurrent per-project fallback.
- Project waves produce a single aggregated `Loaded N manifests in (...)` log entry.

## Related Issue

N/A

## Motivation and Context

Loading a workspace containing approximately 550–700 manifests took up to 2.5 minutes after invalidating the manifest cache.

Investigation showed that Swift compilation was already parallel and relatively fast. Most of the cold-load time was spent launching hundreds of newly generated manifest executables. On macOS, every unique Mach-O executable can require a first-execution security assessment, which causes the parallel workers to gradually stall while launching the binaries.

Interpreting manifests avoided the per-binary launch cost, but it changed an important property of the existing loader: compiled manifests could no longer be reused with different runtime environment variables and manifest flags.

This implementation keeps the compile-once/run-many behavior while reducing the number of generated executables and process launches:

1. Manifests are compiled independently and in parallel into cached object files.
2. All compatible objects in a loading wave are linked into one runner.
3. The runner is launched once and dumps every linked manifest sequentially.
4. Environment variables and manifest flags are evaluated at runner execution time.

This preserves support for environment-dependent manifests without recompilation while avoiding hundreds of unique executable launches during a cold generation.

## How Has This Been Tested?

Tested on macOS with Apple Swift 6.2.4 and Xcode 26.3.

The following builds completed successfully:

- `swift build --target GekoLoader`
- `swift build --product geko`
- `swift build -c release --product geko`
- CI-style universal release bundling for `arm64` and `x86_64`

Automated tests:

- `swift test --filter RecursiveManifestLoaderTests`
  - 7 tests passed.
  - Verifies that explicitly listed projects are loaded in one batch and transitive dependencies form subsequent waves.
- `swift test --filter ManifestLoaderTests`
  - 18 tests passed.
  - Covers project, workspace, config, plugin, template, package settings, invalid manifests, and recursive loading.
- Added an integration test that loads multiple projects through the batch API, changes a manifest flag, and loads the same cached objects again.
  - The second run observes the updated runtime environment without recompilation.

Manual smoke testing covered:

- Cold object and runner cache creation.
- Warm loading using cached objects and runners.
- A workspace wave containing multiple project manifests.
- `Project.swift`, `Workspace.swift`, and `Config.swift`.
- Manifest extension files such as `Project+Name.swift`.
- Partial invalidation after changing a single manifest extension.
- Projects using `ProjectDescriptionHelpers`.
- Debug and release `ProjectDescriptionHelpers`.
- Runtime manifest flags with the same cached runner.
- Release loading against `ProjectDescription.framework`.
- Cache layout verification: one object per manifest and one runner per compatible project wave.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
