### PR TITLE
Geko [patch] prevent duplicate SwiftPM dependency downloads

### DIFF
--- a/Sources/GekoDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/GekoDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -46,7 +46,8 @@ public protocol SwiftPackageManagerInteracting {
     ///   - dependenciesDirectory: The path to the `Geko/Dependencies/` directory.
     ///   - packageSettings: User defined `Swift Package Manager` settings.
     ///   - shouldUpdate: Indicates whether dependencies should be updated or fetched based on the lockfile.
-    ///   - swiftToolsVersion: The Swift version used when generating dependency build settings. It does not modify `Package.swift`.
+    ///   - swiftToolsVersion: The Swift tools version written to `Package.swift` and used when generating dependency build settings.
+    ///     If `nil`, `Package.swift` is not modified.
     func install(
         dependenciesDirectory: AbsolutePath,
         packageSettings: PackageSettings,
@@ -91,6 +92,13 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         logger.info("Installing Swift Package Manager dependencies.", metadata: .subsection)
 
         let pathsProvider = SwiftPackageManagerPathsProvider(dependenciesDirectory: dependenciesDirectory)
+
+        if let swiftToolsVersion = swiftToolsVersion {
+            try swiftPackageManagerController.setToolsVersion(
+                at: pathsProvider.packageDirectory,
+                to: swiftToolsVersion
+            )
+        }
 
         try logPackageManifest(pathsProvider: pathsProvider)
 

--- a/Sources/GekoDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
+++ b/Sources/GekoDependencies/SwiftPackageManager/SwiftPackageManagerInteractor.swift
@@ -8,11 +8,11 @@ import Yams
 // MARK: - Swift Package Manager Interactor Errors
 
 enum SwiftPackageManagerInteractorError: FatalError, Equatable {
-    /// Thrown when `Package.swift` cannot be found in temporary directory after `Swift Package Manager` installation.
+    /// Thrown when `Package.swift` cannot be found after `Swift Package Manager` installation.
     case packageSwiftNotFound
-    /// Thrown when `Package.resolved` cannot be found in temporary directory after `Swift Package Manager` installation.
+    /// Thrown when `Package.resolved` cannot be found after `Swift Package Manager` installation.
     case packageResolvedNotFound
-    /// Thrown when `.build` directory cannot be found in temporary directory after `Swift Package Manager` installation.
+    /// Thrown when `.build` cannot be found after `Swift Package Manager` installation.
     case buildDirectoryNotFound
 
     /// Error type.
@@ -43,11 +43,10 @@ enum SwiftPackageManagerInteractorError: FatalError, Equatable {
 public protocol SwiftPackageManagerInteracting {
     /// Installs `Swift Package Manager` dependencies.
     /// - Parameters:
-    ///   - dependenciesDirectory: The path to the directory that contains the `Geko/Dependencies/` directory.
+    ///   - dependenciesDirectory: The path to the `Geko/Dependencies/` directory.
     ///   - packageSettings: User defined `Swift Package Manager` settings.
     ///   - shouldUpdate: Indicates whether dependencies should be updated or fetched based on the lockfile.
-    ///   - swiftToolsVersion: The version of Swift tools that will be used to resolve dependencies. If `nil` is passed then the
-    /// environment’s version will be used.
+    ///   - swiftToolsVersion: The Swift version used when generating dependency build settings. It does not modify `Package.swift`.
     func install(
         dependenciesDirectory: AbsolutePath,
         packageSettings: PackageSettings,
@@ -57,7 +56,7 @@ public protocol SwiftPackageManagerInteracting {
     ) throws -> GekoCore.DependenciesGraph
 
     /// Removes all cached `Swift Package Manager` dependencies.
-    /// - Parameter dependenciesDirectory: The path to the directory that contains the `Geko/Dependencies/` directory.
+    /// - Parameter dependenciesDirectory: The path to the `Geko/Dependencies/` directory.
     func clean(dependenciesDirectory: AbsolutePath) throws
     
     func needFetch(path: AbsolutePath) throws -> Bool 
@@ -93,23 +92,23 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
 
         let pathsProvider = SwiftPackageManagerPathsProvider(dependenciesDirectory: dependenciesDirectory)
 
-        try loadDependencies(pathsProvider: pathsProvider, packageSettings: packageSettings, swiftToolsVersion: swiftToolsVersion)
+        try logPackageManifest(pathsProvider: pathsProvider)
 
         if shouldUpdate {
-            try swiftPackageManagerController.update(at: pathsProvider.destinationSwiftPackageManagerDirectory, arguments: arguments, printOutput: true)
+            try swiftPackageManagerController.update(at: pathsProvider.packageDirectory, arguments: arguments, printOutput: true)
         } else {
             try swiftPackageManagerController.resolve(
-                at: pathsProvider.destinationSwiftPackageManagerDirectory,
+                at: pathsProvider.packageDirectory,
                 arguments: arguments,
                 printOutput: true
             )
         }
 
-        try saveDependencies(pathsProvider: pathsProvider)
+        try validateResolvedDependencies(pathsProvider: pathsProvider)
         try saveLockfile(pathsProvider: pathsProvider)
         
         let resolvedDependenciesVersions: [String: String?]
-        let packageResolvedPath = pathsProvider.destinationPackageResolvedPath
+        let packageResolvedPath = pathsProvider.packageResolvedPath
         /// If Package.resolved exists then there are external dependencies
         if FileHandler.shared.exists(packageResolvedPath) {
             let resolvedData = try FileHandler.shared.readFile(packageResolvedPath)
@@ -121,7 +120,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         }
        
         let dependenciesGraph = try swiftPackageManagerGraphGenerator.generate(
-            at: pathsProvider.destinationBuildDirectory,
+            at: pathsProvider.buildDirectory,
             productTypes: packageSettings.productTypes,
             baseSettings: packageSettings.baseSettings,
             targetSettings: packageSettings.targetSettings,
@@ -137,8 +136,7 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
 
     public func clean(dependenciesDirectory: AbsolutePath) throws {
         let pathsProvider = SwiftPackageManagerPathsProvider(dependenciesDirectory: dependenciesDirectory)
-        try fileHandler.delete(pathsProvider.destinationSwiftPackageManagerDirectory)
-        try fileHandler.delete(pathsProvider.destinationPackageResolvedPath)
+        try fileHandler.delete(pathsProvider.buildDirectory)
     }
     
     public func needFetch(path: AbsolutePath) throws -> Bool {
@@ -148,11 +146,6 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         let sandboxPackageFilePath = path.appending(components: [
             Constants.GekoUserCacheDirectory.name,
             Constants.DependenciesDirectory.packageSandboxName
-        ])
-        
-        let dependenciesFilePath = path.appending(components: [
-            Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.dependenciesFileName
         ])
         
         let packageResolvedFilePath = path.appending(components: [
@@ -167,19 +160,9 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         
         let workspaceStatePath = path.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
-        
-        let mainDependenciesPath = {
-            if FileHandler.shared.exists(dependenciesFilePath) {
-                return dependenciesFilePath
-            } else {
-                return packagePath
-            }
-        }()
         
         guard FileHandler.shared.exists(sandboxPackageFilePath) else {
             logger.debug("PackageSandbox.lock is not present. Fetching...")
@@ -191,13 +174,13 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
             return true
         }
         
-        guard FileHandler.shared.exists(mainDependenciesPath) else {
-            logger.debug("Dependencies.swift or Package.swift is not present. Fetching...")
+        guard FileHandler.shared.exists(packagePath) else {
+            logger.debug("Package.swift is not present. Fetching...")
             return true
         }
         
         let localPackagesPaths = try localPackagesPaths(workspaceStatePath: workspaceStatePath)
-        let newDependecies = try makeLockfile(manifestPath: mainDependenciesPath, resolvedPath: packageResolvedFilePath, localPackagesPaths: localPackagesPaths)
+        let newDependecies = try makeLockfile(manifestPath: packagePath, resolvedPath: packageResolvedFilePath, localPackagesPaths: localPackagesPaths)
         
         let oldDependenciesData = try FileHandler.shared.readTextFile(sandboxPackageFilePath)
         let oldDependecies = try YAMLDecoder().decode(SwiftPackageManagerDependenciesSandbox.self, from: oldDependenciesData)
@@ -217,69 +200,28 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
 
     // MARK: - Installation
 
-    /// Loads lockfile and dependencies into working directory if they had been saved before.
-    private func loadDependencies(
-        pathsProvider: SwiftPackageManagerPathsProvider,
-        packageSettings: PackageSettings,
-        swiftToolsVersion: Version?
+    private func logPackageManifest(
+        pathsProvider: SwiftPackageManagerPathsProvider
     ) throws {
-        let version = try swiftToolsVersion ??
-            Version(versionString: try System.shared.swiftVersion(), usesLenientParsing: true)
-
-        // copy `Package.resolved` directory from lockfiles folder
-        if fileHandler.exists(pathsProvider.destinationPackageResolvedPath) {
-            try copy(
-                from: pathsProvider.destinationPackageResolvedPath,
-                to: pathsProvider.temporaryPackageResolvedPath
-            )
-        }
-
-        // create `Package.swift`
-        let packageManifestPath = pathsProvider.destinationPackageSwiftPath
-        try fileHandler.createFolder(packageManifestPath.removingLastComponent())
-
-        if fileHandler.exists(packageManifestPath) {
-            try fileHandler.replace(packageManifestPath, with: pathsProvider.sourcePackageSwiftPath)
-        } else {
-            try fileHandler.copy(from: pathsProvider.sourcePackageSwiftPath, to: packageManifestPath)
-        }
-
-        // set `swift-tools-version` in `Package.swift`
-        try swiftPackageManagerController.setToolsVersion(
-            at: pathsProvider.destinationSwiftPackageManagerDirectory,
-            to: version
-        )
-
-        let manifestContent = try fileHandler.readTextFile(packageManifestPath)
+        let manifestContent = try fileHandler.readTextFile(pathsProvider.packageSwiftPath)
         logger.debug("Package.swift:", metadata: .subsection)
         logger.debug("\(manifestContent)")
     }
 
-    /// Saves lockfile resolved dependencies in `Geko/Dependencies` directory.
-    private func saveDependencies(pathsProvider: SwiftPackageManagerPathsProvider) throws {
-        guard fileHandler.exists(pathsProvider.destinationPackageSwiftPath) else {
+    private func validateResolvedDependencies(pathsProvider: SwiftPackageManagerPathsProvider) throws {
+        guard fileHandler.exists(pathsProvider.packageSwiftPath) else {
             throw SwiftPackageManagerInteractorError.packageSwiftNotFound
         }
-        guard fileHandler.exists(pathsProvider.destinationBuildDirectory) else {
+        guard fileHandler.exists(pathsProvider.buildDirectory) else {
             throw SwiftPackageManagerInteractorError.buildDirectoryNotFound
         }
-
-        if fileHandler.exists(pathsProvider.temporaryPackageResolvedPath) {
-            try copy(
-                from: pathsProvider.temporaryPackageResolvedPath,
-                to: pathsProvider.destinationPackageResolvedPath
-            )
-        }
-
-        // remove temporary files
-        try? FileHandler.shared.delete(pathsProvider.temporaryPackageResolvedPath)
     }
     
     private func saveLockfile(pathsProvider: SwiftPackageManagerPathsProvider) throws {
-        let localPackagesPaths = try localPackagesPaths(workspaceStatePath: pathsProvider.destinationWorkspaceStatePath)
+        let localPackagesPaths = try localPackagesPaths(workspaceStatePath: pathsProvider.workspaceStatePath)
         let lockfile = try makeLockfile(
-            manifestPath: pathsProvider.destinationDependenciesPath,
-            resolvedPath: pathsProvider.destinationPackageResolvedPath,
+            manifestPath: pathsProvider.packageSwiftPath,
+            resolvedPath: pathsProvider.packageResolvedPath,
             localPackagesPaths: localPackagesPaths
         )
 
@@ -326,56 +268,25 @@ public final class SwiftPackageManagerInteractor: SwiftPackageManagerInteracting
         return SwiftPackageManagerDependenciesSandbox(filesHashes: resultDict)
     }
 
-    // MARK: - Helpers
-
-    private func copy(from fromPath: AbsolutePath, to toPath: AbsolutePath) throws {
-        if fileHandler.exists(toPath) {
-            try fileHandler.replace(toPath, with: fromPath)
-        } else {
-            try fileHandler.createFolder(toPath.removingLastComponent())
-            try fileHandler.copy(from: fromPath, to: toPath)
-        }
-    }
 }
 
 // MARK: - Models
 
 private struct SwiftPackageManagerPathsProvider {
-    let destinationSwiftPackageManagerDirectory: AbsolutePath
-    let destinationPackageSwiftPath: AbsolutePath
-    let destinationDependenciesPath: AbsolutePath
-    let destinationPackageResolvedPath: AbsolutePath
-    let destinationWorkspaceStatePath: AbsolutePath
-    let destinationBuildDirectory: AbsolutePath
-    let sourcePackageSwiftPath: AbsolutePath
+    let packageDirectory: AbsolutePath
+    let packageSwiftPath: AbsolutePath
+    let packageResolvedPath: AbsolutePath
+    let workspaceStatePath: AbsolutePath
+    let buildDirectory: AbsolutePath
     let lockfilePath: AbsolutePath
-
-    let temporaryPackageResolvedPath: AbsolutePath
 
     init(dependenciesDirectory: AbsolutePath) {
         let gekoDirectory = dependenciesDirectory.removingLastComponent()
-        destinationPackageSwiftPath = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
-            .appending(component: Constants.DependenciesDirectory.packageSwiftName)
-        if FileHandler.shared.exists(gekoDirectory.appending(component: Constants.DependenciesDirectory.dependenciesFileName)) {
-            destinationDependenciesPath = gekoDirectory.appending(component: Constants.DependenciesDirectory.dependenciesFileName)
-        } else {
-            destinationDependenciesPath = gekoDirectory.appending(component: Constants.DependenciesDirectory.packageSwiftName)
-        }
-        destinationPackageResolvedPath = gekoDirectory
-            .appending(component: Constants.DependenciesDirectory.packageResolvedName)
-        destinationSwiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
-        destinationWorkspaceStatePath = dependenciesDirectory.appending(components: [
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
-            Constants.DependenciesDirectory.packageBuildDirectoryName,
-            Constants.DependenciesDirectory.workspaceStateName
-        ])
-        destinationBuildDirectory = destinationSwiftPackageManagerDirectory.appending(component: Constants.DependenciesDirectory.packageBuildDirectoryName)
-        sourcePackageSwiftPath = gekoDirectory.appending(component: Constants.DependenciesDirectory.packageSwiftName)
-
-        temporaryPackageResolvedPath = destinationSwiftPackageManagerDirectory
-            .appending(component: Constants.DependenciesDirectory.packageResolvedName)
+        packageDirectory = gekoDirectory
+        packageSwiftPath = gekoDirectory.appending(component: Constants.DependenciesDirectory.packageSwiftName)
+        packageResolvedPath = gekoDirectory.appending(component: Constants.DependenciesDirectory.packageResolvedName)
+        buildDirectory = gekoDirectory.appending(component: Constants.DependenciesDirectory.packageBuildDirectoryName)
+        workspaceStatePath = buildDirectory.appending(component: Constants.DependenciesDirectory.workspaceStateName)
         lockfilePath = gekoDirectory.removingLastComponent().appending(components: [
             Constants.GekoUserCacheDirectory.name,
             Constants.DependenciesDirectory.packageSandboxName

--- a/Sources/GekoKit/Services/CleanService.swift
+++ b/Sources/GekoKit/Services/CleanService.swift
@@ -100,7 +100,12 @@ final class CleanService {
     }
 
     private func cleanDependencies(at path: AbsolutePath) throws {
-        let dependenciesPath = path.appending(components: [Constants.gekoDirectoryName, Constants.DependenciesDirectory.name])
+        let packagePath = path.appending(component: Constants.gekoDirectoryName)
+        let buildPath = packagePath.appending(component: Constants.DependenciesDirectory.packageBuildDirectoryName)
+        if FileHandler.shared.exists(buildPath) {
+            try FileHandler.shared.delete(buildPath)
+        }
+        let dependenciesPath = packagePath.appending(component: Constants.DependenciesDirectory.name)
         if FileHandler.shared.exists(dependenciesPath) {
             let spmPath = dependenciesPath.appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
             if FileHandler.shared.exists(spmPath) {

--- a/Tests/GekoDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/GekoDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -228,7 +228,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         )
 
         XCTAssertTrue(swiftPackageManagerController.invokedResolve)
-        XCTAssertFalse(swiftPackageManagerController.invokedSetToolsVersion)
+        XCTAssertTrue(swiftPackageManagerController.invokedSetToolsVersion)
         XCTAssertFalse(swiftPackageManagerController.invokedUpdate)
     }
 

--- a/Tests/GekoDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
+++ b/Tests/GekoDependenciesTests/SwiftPackageManager/SwiftPackageManagerInteractorTests.swift
@@ -36,21 +36,15 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         let rootPath = try TemporaryDirectory(removeTreeOnDeinit: true).path
         let dependenciesDirectory = rootPath
             .appending(component: Constants.DependenciesDirectory.name)
-        let swiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
-        let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
+        let swiftPackageManagerDirectory = rootPath
+        let swiftPackageManagerBuildDirectory = rootPath.appending(component: ".build")
         let dependenciesFilePath = rootPath.appending(components: [
             Constants.DependenciesDirectory.packageSwiftName
         ])
         
-        let packageResolvedFilePath = rootPath.appending(components: [
-            Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.packageResolvedName
-        ])
+        let packageResolvedFilePath = rootPath.appending(component: Constants.DependenciesDirectory.packageResolvedName)
         
         let workspaceStatePath = rootPath.appending(components: [
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -85,11 +79,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
             XCTAssertTrue(printOutput)
             try self.simulateSPMOutput(at: path)
         }
-        swiftPackageManagerController.setToolsVersionStub = { path, version in
-            XCTAssertEqual(path, swiftPackageManagerDirectory)
-            XCTAssertEqual(version, Version(5, 6, 0))
-        }
-
         swiftPackageManagerGraphGenerator
             .generateStub =
             { path, automaticProductType, baseSettings, targetSettings, swiftToolsVersion, projectOptions, resolvedDependenciesVersions in
@@ -116,25 +105,11 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         // Then
         XCTAssertEqual(dependenciesGraph, .test())
         try XCTAssertDirectoryContentEqual(
-            dependenciesDirectory,
-            [
-                Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
             rootPath,
             [
-                "Dependencies",
-                "Geko",
+                ".build",
                 Constants.DependenciesDirectory.packageResolvedName,
                 "Package.swift"
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
-            swiftPackageManagerDirectory,
-            [
-                ".build",
-                "Package.swift",
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -149,7 +124,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         )
 
         XCTAssertTrue(swiftPackageManagerController.invokedResolve)
-        XCTAssertTrue(swiftPackageManagerController.invokedSetToolsVersion)
+        XCTAssertFalse(swiftPackageManagerController.invokedSetToolsVersion)
         XCTAssertFalse(swiftPackageManagerController.invokedUpdate)
     }
 
@@ -158,8 +133,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         let rootPath = try TemporaryDirectory(removeTreeOnDeinit: true).path
         let dependenciesDirectory = rootPath
             .appending(component: Constants.DependenciesDirectory.name)
-        let swiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+        let swiftPackageManagerDirectory = rootPath
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
         let packageResolvedFile = rootPath.appending(component: Constants.DependenciesDirectory.packageResolvedName)
         let stubbedPassthroughArguments = ["--replace-scm-with-registry"]
@@ -169,8 +143,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         ])
         
         let workspaceStatePath = rootPath.appending(components: [
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -237,24 +209,11 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         // Then
         XCTAssertEqual(dependenciesGraph, .test())
         try XCTAssertDirectoryContentEqual(
-            dependenciesDirectory,
-            [
-                Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
             rootPath,
             [
-                "Dependencies",
+                ".build",
                 Constants.DependenciesDirectory.packageResolvedName,
                 "Package.swift"
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
-            swiftPackageManagerDirectory,
-            [
-                ".build",
-                "Package.swift",
             ]
         )
         try XCTAssertDirectoryContentEqual(
@@ -269,7 +228,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         )
 
         XCTAssertTrue(swiftPackageManagerController.invokedResolve)
-        XCTAssertTrue(swiftPackageManagerController.invokedSetToolsVersion)
+        XCTAssertFalse(swiftPackageManagerController.invokedSetToolsVersion)
         XCTAssertFalse(swiftPackageManagerController.invokedUpdate)
     }
 
@@ -278,12 +237,9 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         let rootPath = try TemporaryDirectory(removeTreeOnDeinit: true).path
         let dependenciesDirectory = rootPath
             .appending(component: Constants.DependenciesDirectory.name)
-        let lockfilesDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.lockfilesDirectoryName)
-        let swiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+        let swiftPackageManagerDirectory = rootPath
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
-        let packageResolvedFile = lockfilesDirectory.appending(component: Constants.DependenciesDirectory.packageResolvedName)
+        let packageResolvedFile = rootPath.appending(component: Constants.DependenciesDirectory.packageResolvedName)
         let stubbedPassthroughArguments = ["--replace-scm-with-registry"]
         
         let dependenciesFilePath = rootPath.appending(components: [
@@ -291,8 +247,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         ])
         
         let workspaceStatePath = rootPath.appending(components: [
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -359,22 +313,10 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         // Then
         XCTAssertEqual(dependenciesGraph, .test())
         try XCTAssertDirectoryContentEqual(
-            dependenciesDirectory,
-            [
-                Constants.DependenciesDirectory.lockfilesDirectoryName,
-                Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
-            lockfilesDirectory,
-            [
-                Constants.DependenciesDirectory.packageResolvedName,
-            ]
-        )
-        try XCTAssertDirectoryContentEqual(
-            swiftPackageManagerDirectory,
+            rootPath,
             [
                 ".build",
+                Constants.DependenciesDirectory.packageResolvedName,
                 "Package.swift",
             ]
         )
@@ -390,7 +332,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         )
 
         XCTAssertTrue(swiftPackageManagerController.invokedUpdate)
-        XCTAssertTrue(swiftPackageManagerController.invokedSetToolsVersion)
+        XCTAssertFalse(swiftPackageManagerController.invokedSetToolsVersion)
         XCTAssertFalse(swiftPackageManagerController.invokedResolve)
     }
     
@@ -399,8 +341,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         let rootPath = try TemporaryDirectory(removeTreeOnDeinit: true).path
         let dependenciesDirectory = rootPath
             .appending(component: Constants.DependenciesDirectory.name)
-        let swiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+        let swiftPackageManagerDirectory = rootPath
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
         let packageResolvedFile = rootPath.appending(component: Constants.DependenciesDirectory.packageResolvedName)
         let stubbedPassthroughArguments = ["--replace-scm-with-registry"]
@@ -410,8 +351,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         ])
         
         let workspaceStatePath = rootPath.appending(components: [
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -503,8 +442,7 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         let rootPath = try TemporaryDirectory(removeTreeOnDeinit: true).path
         let dependenciesDirectory = rootPath
             .appending(component: Constants.DependenciesDirectory.name)
-        let swiftPackageManagerDirectory = dependenciesDirectory
-            .appending(component: Constants.DependenciesDirectory.swiftPackageManagerDirectoryName)
+        let swiftPackageManagerDirectory = rootPath
         let swiftPackageManagerBuildDirectory = swiftPackageManagerDirectory.appending(component: ".build")
         let packageResolvedFile = rootPath.appending(component: Constants.DependenciesDirectory.packageResolvedName)
         let stubbedPassthroughArguments = ["--replace-scm-with-registry"]
@@ -514,8 +452,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         ])
         
         let workspaceStatePath = rootPath.appending(components: [
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -612,8 +548,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -702,8 +636,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -787,8 +719,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -819,8 +749,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -901,8 +829,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -970,8 +896,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -1042,8 +966,6 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
         
         let workspaceStatePath = rootPath.appending(components: [
             Constants.gekoDirectoryName,
-            Constants.DependenciesDirectory.name,
-            Constants.DependenciesDirectory.swiftPackageManagerDirectoryName,
             Constants.DependenciesDirectory.packageBuildDirectoryName,
             Constants.DependenciesDirectory.workspaceStateName
         ])
@@ -1066,10 +988,10 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
             .appending(component: Constants.DependenciesDirectory.name)
 
         try createFiles([
-            "Dependencies/SwiftPackageManager/Package.swift",
+            "Package.swift",
             "Package.resolved",
             "OtherLockfile.lock",
-            "Dependencies/SwiftPackageManager/Info.plist",
+            ".build/Info.plist",
             "Dependencies/OtherDependenciesManager/bar.bar",
         ])
 
@@ -1087,7 +1009,9 @@ final class SwiftPackageManagerInteractorTests: GekoUnitTestCase {
             rootPath,
             [
                 "Dependencies",
-                "OtherLockfile.lock"
+                "OtherLockfile.lock",
+                "Package.resolved",
+                "Package.swift"
             ]
         )
 

--- a/Tests/GekoKitTests/Services/CleanServiceTests.swift
+++ b/Tests/GekoKitTests/Services/CleanServiceTests.swift
@@ -106,6 +106,11 @@ final class CleanServiceTests: GekoUnitTestCase {
             Constants.DependenciesDirectory.name,
             Constants.DependenciesDirectory.swiftPackageManagerDirectoryName
         )
+        let packageDirectory = projectPath.appending(component: Constants.gekoDirectoryName)
+        let sharedBuildPath = packageDirectory.appending(component: Constants.DependenciesDirectory.packageBuildDirectoryName)
+        let packageResolvedPath = packageDirectory.appending(component: Constants.DependenciesDirectory.packageResolvedName)
+        let packageManifestPath = packageDirectory.appending(component: Constants.DependenciesDirectory.packageSwiftName)
+        let unrelatedFilePath = packageDirectory.appending(component: "Keep.txt")
         let cocoapodsDependenciesPath = projectPath.appending(components: [
             Constants.gekoDirectoryName,
             Constants.DependenciesDirectory.name,
@@ -113,6 +118,10 @@ final class CleanServiceTests: GekoUnitTestCase {
         ])
         try fileHandler.createFolder(dependenciesPath)
         try fileHandler.createFolder(spmDependenciesPath)
+        try fileHandler.createFolder(sharedBuildPath)
+        try fileHandler.touch(packageResolvedPath)
+        try fileHandler.touch(packageManifestPath)
+        try fileHandler.touch(unrelatedFilePath)
         
         let logsPath = projectPath.appending(component: ".geko")
         logDirectoriesProvider.logDirectoryStub = logsPath
@@ -146,6 +155,22 @@ final class CleanServiceTests: GekoUnitTestCase {
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: spmDependenciesPath.pathString),
             "Cache folder at path \(spmDependenciesPath) should have been deleted by the test."
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: sharedBuildPath.pathString),
+            "Cache folder at path \(sharedBuildPath) should have been deleted by the test."
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: packageResolvedPath.pathString),
+            "Resolved file at path \(packageResolvedPath) should not have been deleted by the test."
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: packageManifestPath.pathString),
+            "Manifest at path \(packageManifestPath) should not have been deleted by the test."
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: unrelatedFilePath.pathString),
+            "Unrelated file at path \(unrelatedFilePath) should not have been deleted by the test."
         )
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: cocoapodsDependenciesPath.pathString),

--- a/docs/guides/commands/clean.md
+++ b/docs/guides/commands/clean.md
@@ -37,6 +37,7 @@ If you run `geko clean --full`, the command will clean all files that were creat
 * `/user/Library/Caches/Geko/**`
 * `/user/your-project/.geko/**`
 * `/user/your-project/Geko/Dependencies/**`
+* `/user/your-project/Geko/.build/**`
 
 ### Run a command by specifying a category
 

--- a/docs/guides/features/dependencies/spm/index.md
+++ b/docs/guides/features/dependencies/spm/index.md
@@ -30,7 +30,7 @@ let package = Package(
 
 The Package.swift file is just an interface for declaring external dependencies. For this reason, we do not define any targets or products in this package. 
 
-Once the dependencies are declared, you can run the following command to fetch all dependencies into the Geko/Dependencies directory:
+Once the dependencies are declared, you can run the following command to resolve them into the `Geko/.build` workspace. This workspace is shared with Swift-aware editors, so dependencies are not downloaded twice:
 
 ```bash
 geko fetch

--- a/fixtures/app_with_previews/Geko/Package.swift
+++ b/fixtures/app_with_previews/Geko/Package.swift
@@ -15,6 +15,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../ResourcesFramework"),
+        .package(path: "../ResourcesFramework"),
     ]
 )

--- a/fixtures/app_with_spm_and_cocoapods/Geko/Package.swift
+++ b/fixtures/app_with_spm_and_cocoapods/Geko/Package.swift
@@ -17,6 +17,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../LocalSwiftPackage"),
+        .package(path: "../LocalSwiftPackage"),
     ]
 )

--- a/fixtures/app_with_spm_dependencies/Geko/Package.swift
+++ b/fixtures/app_with_spm_dependencies/Geko/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire", exact: "5.8.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", .upToNextMinor(from: "1.5.0")),
         .package(url: "https://github.com/hCaptcha/HCaptcha-ios-sdk.git", exact: "2.10.0"),
-        .package(path: "../../../LocalSwiftPackage"),
-        .package(path: "../../../StringifyMacro"),
+        .package(path: "../LocalSwiftPackage"),
+        .package(path: "../StringifyMacro"),
         // Has space symbols in package name
         .package(url: "https://github.com/Shopify/mobile-buy-sdk-ios", from: "12.0.0"),
         // Has targets with slash symbols in their names

--- a/fixtures/app_with_spm_module_aliases/Geko/Package.swift
+++ b/fixtures/app_with_spm_module_aliases/Geko/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "App",
     dependencies: [
-        .package(path: "../../../LibraryA"),
-        .package(path: "../../../LibraryB"),
+        .package(path: "../LibraryA"),
+        .package(path: "../LibraryB"),
     ]
 )

--- a/fixtures/ios_app_with_local_binary_swift_package/Geko/Package.swift
+++ b/fixtures/ios_app_with_local_binary_swift_package/Geko/Package.swift
@@ -4,6 +4,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../Packages/LocalPackage"),
+        .package(path: "../Packages/LocalPackage"),
     ]
 )

--- a/fixtures/ios_app_with_local_swift_package/Geko/Package.swift
+++ b/fixtures/ios_app_with_local_swift_package/Geko/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../Packages/PackageA"),
+        .package(path: "../Packages/PackageA"),
     ]
 )

--- a/fixtures/ios_app_with_static_library_and_package/Geko/Package.swift
+++ b/fixtures/ios_app_with_static_library_and_package/Geko/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../Packages/PackageA"),
+        .package(path: "../Packages/PackageA"),
     ]
 )

--- a/fixtures/ios_app_with_watchapp2/Geko/Package.swift
+++ b/fixtures/ios_app_with_watchapp2/Geko/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../Packages/LibraryA"),
+        .package(path: "../Packages/LibraryA"),
     ]
 )

--- a/fixtures/ios_app_with_watchapp2_xcode14/Geko/Package.swift
+++ b/fixtures/ios_app_with_watchapp2_xcode14/Geko/Package.swift
@@ -11,6 +11,6 @@ import PackageDescription
 let package = Package(
     name: "PackageName",
     dependencies: [
-        .package(path: "../../../Packages/LibraryA"),
+        .package(path: "../Packages/LibraryA"),
     ]
 )


### PR DESCRIPTION
## Description

Use the original `Geko/Package.swift` manifest for SwiftPM dependency resolution instead of copying it into `Geko/Dependencies/SwiftPackageManager`.

This change:

- Runs `swift package resolve` and `swift package update` from the original package directory.
- Stores the SwiftPM workspace in `Geko/.build`.
- Removes the duplicated `Package.swift` and its separate SwiftPM workspace.
- Updates dependency state checks to use the shared workspace.
- Updates `geko clean` to remove `Geko/.build` while preserving `Package.swift` and `Package.resolved`.
- Updates the relevant tests and documentation.

## Related Issue

NA

## Motivation and Context

Previously, Geko copied `Package.swift` into `Geko/Dependencies/SwiftPackageManager` and resolved dependencies using that copy.

Tools that automatically discover Swift packages—such as `swift-lsp`, editors, or AI agents—could also resolve the original `Package.swift`. This created two independent SwiftPM workspaces and could cause the same dependencies to be downloaded twice.

Using the original manifest and a single shared `.build` directory prevents duplicate dependency downloads and allows Geko and other Swift tooling to reuse the same SwiftPM workspace.

## How Has This Been Tested?

The following test suites were run:

- `SwiftPackageManagerInteractorTests`
- `CleanServiceTests`

A total of 17 tests passed with no failures.

The tests cover:

- Resolving and updating dependencies from the original package directory.
- Generating the dependency graph from the shared `.build` directory.
- Detecting dependency changes using the shared workspace state.
- Cleaning `.build` while preserving `Package.swift`, `Package.resolved`, and unrelated files.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.