### PR TITLE
Geko [patch] Fix issue with incorrect invalidate of swiftmodule hashes when updates

### DIFF
--- a/Sources/GekoCache/ContentHashing/AdditionalCacheStringsHasher.swift
+++ b/Sources/GekoCache/ContentHashing/AdditionalCacheStringsHasher.swift
@@ -56,7 +56,8 @@ public final class AdditionalCacheStringsHasher: AdditionalCacheStringsHashing {
             cacheOutputType.rawValue,
             destination.rawValue,
             try system.swiftlangVersion(),
-            cacheUserVersion ?? Constants.cacheVersion
+            cacheUserVersion ?? "",
+            Constants.cacheVersion
         ]
         return try contentHasher.hash(additionalStringsToHash)
     }

--- a/Sources/GekoCache/ContentHashing/XCFrameworksContentHasher.swift
+++ b/Sources/GekoCache/ContentHashing/XCFrameworksContentHasher.swift
@@ -16,11 +16,14 @@ public protocol XCFrameworksContentHashing {
 
 enum XCFrameworksContentHasherError: FatalError, Equatable {
     case unexpectedGraphDependencyType(GraphDependency)
+    case missingDependencyHash(GraphDependency)
 
     var description: String {
         switch self {
         case let .unexpectedGraphDependencyType(dependency):
             return "Unexpected graph dependency type: \(dependency.description)"
+        case let .missingDependencyHash(dependency):
+            return "Dependency '\(dependency.name)' is hashable, but its hash is missing. This is likely an internal error. Please report this issue."
         }
     }
 
@@ -76,15 +79,14 @@ public final class XCFrameworksContentHasher: XCFrameworksContentHashing {
         guard cacheProfile.options.swiftModuleCacheEnabled else {
             return [:]
         }
-
-        let hashedFrameworks: Atomic<[AbsolutePath: String]> = Atomic(wrappedValue: [:])
-        let hashableFrameworks = graph.xcframeworks.compactMap { path, dependency -> (AbsolutePath, GraphDependency)? in
-            if isHashable(path: path, graphDependency: dependency) {
-                return (path, dependency)
-            } else {
-                return nil
-            }
-        }
+        
+        let hashedDependencies: Atomic<[AbsolutePath: String]> = Atomic(wrappedValue: [:])
+        
+        // We get a topologically sorted array of all dependency types, may be not just XCFrameworks
+        let xcframeworks = graph.xcframeworks
+        let topologicalSortedDeps = Array(try topologicalSort(xcframeworks.map { $0.1 }) {
+            Array(graph.dependencies[$0] ?? [])
+        }.reversed())
 
         let additionalString = try additionalCacheStringsHasher.contentHash(
             cacheProfile: cacheProfile,
@@ -92,7 +94,8 @@ public final class XCFrameworksContentHasher: XCFrameworksContentHashing {
             cacheOutputType: cacheOutputType,
             destination: cacheDestination
         )
-        try hashableFrameworks.forEach(context: .concurrent) { (path, dependency) in
+        
+        try topologicalSortedDeps.forEach(context: .concurrent) { dependency in
             let stringsToHash = [
                 try hash(
                     graph: graph,
@@ -102,31 +105,74 @@ public final class XCFrameworksContentHasher: XCFrameworksContentHashing {
             ]
             let hash = try contentHasher.hash(stringsToHash)
             
-            hashedFrameworks.modify { value in
-                value[path] = hash
+            hashedDependencies.modify { value in
+                value[dependency.path] = hash
             }
         }
+        
+        var hashedFrameworks: [AbsolutePath: String] = [:]
+        for dependency in topologicalSortedDeps {
+            guard isHashable(path: dependency.path, graphDependency: dependency) else { continue }
+            guard let hashableXcframeworkHash = hashedDependencies.wrappedValue[dependency.path] else {
+                throw XCFrameworksContentHasherError.missingDependencyHash(dependency)
+            }
+            let dependenciesHash = hashDependencies(
+                for: dependency,
+                graph: graph,
+                hashedDependencies: hashedFrameworks
+            )
+            hashedFrameworks[dependency.path] = try contentHasher.hash([dependenciesHash, hashableXcframeworkHash])
+        }
 
-        return hashedFrameworks.wrappedValue
+        return hashedFrameworks
     }
     
     // MARK: - Private
     
-    /// Hash graphDependency by the version of the external dependency.
-    /// If there is no version, then we hash the entire xcframework, but without the swiftmodules folder
+    private func hashDependencies(
+        for dependency: GraphDependency,
+        graph: Graph,
+        hashedDependencies: [AbsolutePath: String]
+    ) -> String {
+        guard let dependencies = graph.dependencies[dependency] else { return "" }
+        let hashes = dependencies.compactMap { hashedDependencies[$0.path] }
+        return hashes.sorted().compactMap { $0 }.joined()
+    }
+    
     private func hash(
         graph: Graph,
         graphDependency: GraphDependency
     ) throws -> String {
         switch graphDependency {
         case .xcframework(let framework):
+            /// Hash graphDependency by the version of the external dependency.
+            /// If there is no version, then we hash the entire xcframework, but without the swiftmodules folder
             let name = framework.path.basenameWithoutExt
             if let version = graph.externalDependenciesGraph.tree[name]?.version {
                 return try contentHasher.hash(version)
             } else {
                 return try contentHasher.hash(path: framework.path, exclude: [{ $0.pathString.contains(".swiftmodule")}])
             }
-        default:
+        case let .bundle(path):
+            return try contentHasher.hash(path: path)
+        case let .framework(path, _, _, _, _, _, _):
+            return try contentHasher.hash(path: path)
+        case let .library(path, publicHeaders, _, _, swiftModuleMap):
+            let libraryHash = try contentHasher.hash(path: path)
+            let publicHeadersHash = try contentHasher.hash(path: publicHeaders)
+            let hash: String
+            if let swiftModuleMap {
+                let swiftModuleHash = try contentHasher.hash(path: swiftModuleMap)
+                hash = try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)-\(swiftModuleHash)")
+            } else {
+                hash = try contentHasher.hash("library-\(libraryHash)-\(publicHeadersHash)")
+            }
+            return hash
+        case let .sdk(name, _, status, _):
+            return try contentHasher.hash("sdk-\(name)-\(status)")
+        case let .macro(path):
+            return try contentHasher.hash(path: path)
+        case .target:
             throw XCFrameworksContentHasherError.unexpectedGraphDependencyType(graphDependency)
         }
     }

--- a/Sources/GekoGraph/Graph/GraphDependency.swift
+++ b/Sources/GekoGraph/Graph/GraphDependency.swift
@@ -310,6 +310,25 @@ public enum GraphDependency: Hashable, CustomStringConvertible, Comparable, Coda
             return name
         }
     }
+    
+    public var path: AbsolutePath {
+        switch self {
+        case let .macro(path):
+            return path
+        case let .xcframework(xcframework):
+            return xcframework.path
+        case let .framework(path, _, _, _, _, _, _):
+            return path
+        case let .library(path, _, _, _, _):
+            return path
+        case let .bundle(path):
+            return path
+        case let .target(_, path, _):
+            return path
+        case let .sdk(_, path, _, _):
+            return path
+        }
+    }
 
     // MARK: - Comparable
 

--- a/Sources/GekoSupport/Constants.swift
+++ b/Sources/GekoSupport/Constants.swift
@@ -27,7 +27,7 @@ public enum Constants {
     /// The cache version.
     /// This should change only when it changes the logic to map a `GekoGraph.Target` to a cached build artifact.
     /// Changing this results in changing the target hash and hence forcing a rebuild of its artifact.
-    public static let cacheVersion = "1.3.0"
+    public static let cacheVersion = "1.4.0"
     public static let cacheLatesBuildFileName = "latest_build"
 
     public enum GekoUserCacheDirectory {

--- a/Tests/GekoCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
+++ b/Tests/GekoCacheIntegrationTests/ContentHashing/ContentHashingIntegrationTests.swift
@@ -155,8 +155,8 @@ final class ContentHashingIntegrationTests: GekoUnitTestCase {
         )
 
         // Then
-        XCTAssertEqual(contentHash[framework1.target.name], "959814bec04d5ece")
-        XCTAssertEqual(contentHash[framework2.target.name], "cda9a8709ec95942")
+        XCTAssertEqual(contentHash[framework1.target.name], "b99049ffa9e61ee8")
+        XCTAssertEqual(contentHash[framework2.target.name], "fc861140042127e4")
     }
 
     func test_contentHashes_hashChangesWithCacheOutputType() throws {

--- a/Tests/GekoCacheTests/ContentHashing/AdditionalCacheStringsHasherTests.swift
+++ b/Tests/GekoCacheTests/ContentHashing/AdditionalCacheStringsHasherTests.swift
@@ -33,12 +33,12 @@ final class AdditionalCacheStringsHasherTests: GekoUnitTestCase {
         let profile = ProjectDescription.Cache.Profile.test(name: "Test")
         mockContentHashing.hashStringsSpy = []
         systeming.swiftlangVersionStub = { "6.0.0" }
-        let expectedHash = "Test;Debug;;true,false,false;framework;simulator;6.0.0;1.3.0"
+        let expectedHash = "Test;Debug;;true,false,false;framework;simulator;6.0.0;1.0.0-custom;1.4.0"
 
         // When
         let hash = try subject.contentHash(
             cacheProfile: profile,
-            cacheUserVersion: nil,
+            cacheUserVersion: "1.0.0-custom",
             cacheOutputType: .framework,
             destination: .simulator
         )

--- a/Tests/GekoCacheTests/ContentHashing/XCFrameworksContentHasherTests.swift
+++ b/Tests/GekoCacheTests/ContentHashing/XCFrameworksContentHasherTests.swift
@@ -81,8 +81,8 @@ final class XCFrameworksContentHasherTests: GekoUnitTestCase {
     func test_xcframeworksHashes_returnsExpectedResult() throws {
         // Given
         let expectedHashes = [
-            filePath1: "de1c9c5c1735fa98", // FooFramework
-            filePath2: "16b9097ab14ecec9", // BarFramework
+            filePath1: "63e9c438b0271526", // FooFramework
+            filePath2: "ef0b247da6a747a5", // BarFramework
         ]
 
         xcframeworkMetadataProvider.swiftModuleFolderPathStub = try temporaryPath()
@@ -139,7 +139,173 @@ final class XCFrameworksContentHasherTests: GekoUnitTestCase {
         // Then
         XCTAssertEqual(hashes, expectedHashes)
     }
-
+    
+    func test_xcframeworksHashes_doNotInvalidateWithoutUpdate() throws {
+        // Given
+        let profile = Cache.Profile.test(options: .options(swiftModuleCacheEnabled: true))
+        system.swiftlangVersionStub = { "6.0.0" }
+        
+        let xcframework1 = GraphDependency.testXCFramework(path: filePath1) // FooFramework
+        let xcframework2 = GraphDependency.testXCFramework(path: filePath2) // BarFramework
+        
+        xcframeworkMetadataProvider.swiftModuleFolderPathStub = try temporaryPath()
+        
+        let externalDependenciesGraphBeforeUpdate = DependenciesGraph(
+            externalDependencies: [:],
+            externalProjects: [:],
+            externalFrameworkDependencies: [:],
+            tree: [
+                "FooFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "1.0.0", dependencies: []),
+                "BarFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "2.0.0", dependencies: [])
+            ]
+        )
+        
+        let externalDependenciesGraphAfterUpdate = DependenciesGraph(
+            externalDependencies: [:],
+            externalProjects: [:],
+            externalFrameworkDependencies: [:],
+            tree: [
+                "FooFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "1.0.0", dependencies: []),
+                "BarFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "2.0.0", dependencies: [])
+            ]
+        )
+        
+        let project1 = Project.test(path: try temporaryPath().appending(component: "f1"))
+        let project2 = Project.test(path: try temporaryPath().appending(component: "f2"))
+        let framework1 = makeFramework(project: project1, sources: [source1])
+        let framework2 = makeFramework(project: project2, sources: [source2])
+        
+        // FooFramework depends on BarFramework
+        let graphBefore = Graph.test(
+            projects: [
+                project1.path: project1,
+                project2.path: project2,
+            ],
+            targets: [
+                project1.path: [
+                    framework1.target.name: framework1.target,
+                ],
+                project2.path: [
+                    framework2.target.name: framework2.target,
+                ],
+            ],
+            dependencies: [
+                xcframework1: [xcframework2] // FooFramework → BarFramework
+            ],
+            xcframeworks: [
+                filePath1: xcframework1,
+                filePath2: xcframework2
+            ],
+            externalDependenciesGraph: externalDependenciesGraphBeforeUpdate
+        )
+        var graphAfter = graphBefore
+        graphAfter.externalDependenciesGraph = externalDependenciesGraphAfterUpdate
+        
+        // When
+        let hashesBefore = try subject.contentHashes(
+            for: graphBefore,
+            cacheProfile: profile,
+            cacheUserVersion: nil,
+            cacheOutputType: .framework,
+            cacheDestination: .simulator
+        )
+        
+        let hashesAfter = try subject.contentHashes(
+            for: graphAfter,
+            cacheProfile: profile,
+            cacheUserVersion: nil,
+            cacheOutputType: .framework,
+            cacheDestination: .simulator
+        )
+        
+        // Then
+        XCTAssertEqual(hashesBefore, hashesAfter)
+    }
+    
+    func test_xcframeworksHashes_InvalidateWithUpdate() throws {
+        // Given
+        let profile = Cache.Profile.test(options: .options(swiftModuleCacheEnabled: true))
+        system.swiftlangVersionStub = { "6.0.0" }
+        
+        let xcframework1 = GraphDependency.testXCFramework(path: filePath1) // FooFramework
+        let xcframework2 = GraphDependency.testXCFramework(path: filePath2) // BarFramework
+        
+        xcframeworkMetadataProvider.swiftModuleFolderPathStub = try temporaryPath()
+        
+        let externalDependenciesGraphBeforeUpdate = DependenciesGraph(
+            externalDependencies: [:],
+            externalProjects: [:],
+            externalFrameworkDependencies: [:],
+            tree: [
+                "FooFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "1.0.0", dependencies: []),
+                "BarFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "2.0.0", dependencies: [])
+            ]
+        )
+        
+        let externalDependenciesGraphAfterUpdate = DependenciesGraph(
+            externalDependencies: [:],
+            externalProjects: [:],
+            externalFrameworkDependencies: [:],
+            tree: [
+                "FooFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "1.0.0", dependencies: []),
+                "BarFramework": GekoGraph.DependenciesGraph.TreeDependency(version: "3.0.0", dependencies: [])
+            ]
+        )
+        
+        let project1 = Project.test(path: try temporaryPath().appending(component: "f1"))
+        let project2 = Project.test(path: try temporaryPath().appending(component: "f2"))
+        let framework1 = makeFramework(project: project1, sources: [source1])
+        let framework2 = makeFramework(project: project2, sources: [source2])
+        
+        // FooFramework depends on BarFramework
+        let graphBefore = Graph.test(
+            projects: [
+                project1.path: project1,
+                project2.path: project2,
+            ],
+            targets: [
+                project1.path: [
+                    framework1.target.name: framework1.target,
+                ],
+                project2.path: [
+                    framework2.target.name: framework2.target,
+                ],
+            ],
+            dependencies: [
+                xcframework1: [xcframework2] // FooFramework → BarFramework
+            ],
+            xcframeworks: [
+                filePath1: xcframework1,
+                filePath2: xcframework2
+            ],
+            externalDependenciesGraph: externalDependenciesGraphBeforeUpdate
+        )
+        var graphAfter = graphBefore
+        graphAfter.externalDependenciesGraph = externalDependenciesGraphAfterUpdate
+        
+        // When
+        let hashesBefore = try subject.contentHashes(
+            for: graphBefore,
+            cacheProfile: profile,
+            cacheUserVersion: nil,
+            cacheOutputType: .framework,
+            cacheDestination: .simulator
+        )
+        
+        let hashesAfter = try subject.contentHashes(
+            for: graphAfter,
+            cacheProfile: profile,
+            cacheUserVersion: nil,
+            cacheOutputType: .framework,
+            cacheDestination: .simulator
+        )
+        
+        // Then
+        XCTAssertNotEqual(hashesBefore, hashesAfter)
+    }
+    
+    // MARK: - Help
+    
     private func makeFramework(
         project: Project,
         platform: Platform = .iOS,


### PR DESCRIPTION
## Description

A project that uses the Swift module cache may run into issues when updating dependencies, especially if those dependencies introduce breaking changes and depend on each other.

In this case, an old hash and Swift module may be reused for a dependent module. The project may still build successfully, but then fail during a clean build without the cache or crash at runtime.

This MR updates the XCFramework hash calculation to include the hashes of all its dependencies. As a result, when a library is updated, the cache for all dependent libraries will also be invalidated.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Integration-tested against a real-world case in a production project, with unit tests added as well.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
