### PR TITLE
Geko [patch] Test coverage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,19 @@
 name: docs
 
 on:
-  push:
-    branches: [main]
   pull_request:
     paths:
       - 'docs/**'
 
   workflow_dispatch:
+
+  workflow_call:
+    inputs:
+      deploy:
+        description: Deploy the built documentation to GitHub Pages
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,7 +59,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
-    if: github.event_name == 'push'
+    if: inputs.deploy
     runs-on: ubuntu-latest
     name: Deploy
     steps:

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: build_and_test
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
-          set -o pipefail && xcrun swift test --enable-code-coverage | xcbeautify --renderer github-actions --is-ci
+          set -o pipefail && xcrun swift test --parallel --enable-code-coverage | xcbeautify --renderer github-actions --is-ci
 
       - name: Generate code coverage report
         if: steps.only_docs_changes.outputs.run == 'true'
@@ -60,6 +60,7 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           swift test \
+            --parallel \
             --filter GekoAcceptanceTests \
             --filter GekoSupportTests \
             --filter GekoCoreIntegrationTests \

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -33,7 +33,10 @@ jobs:
       - name: build_and_test
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
-          set -o pipefail && xcrun swift test --parallel --enable-code-coverage | xcbeautify --renderer github-actions --is-ci
+          set -o pipefail
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel --enable-code-coverage \
+            | tee /dev/stderr \
+            | xcbeautify --renderer github-actions --is-ci
 
       - name: Generate code coverage report
         if: steps.only_docs_changes.outputs.run == 'true'

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -33,7 +33,11 @@ jobs:
       - name: build_and_test
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
-          set -o pipefail && xcrun swift test | xcbeautify --renderer github-actions --is-ci
+          set -o pipefail && xcrun swift test --enable-code-coverage | xcbeautify --renderer github-actions --is-ci
+
+      - name: Generate code coverage report
+        if: steps.only_docs_changes.outputs.run == 'true'
+        run: ./scripts/utils/code-coverage.sh
 
   build_and_test_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           set -o pipefail
-          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel  \ 
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel \ 
             | tee /dev/stderr \
             | xcbeautify --renderer github-actions --is-ci
 

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           set -o pipefail
-          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel \ 
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel \
             | tee /dev/stderr \
             | xcbeautify --renderer github-actions --is-ci
 

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -34,7 +34,7 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           set -o pipefail
-          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel \
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test \
             | tee /dev/stderr \
             | xcbeautify --renderer github-actions --is-ci
 

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -34,13 +34,14 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           set -o pipefail
-          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel --enable-code-coverage \
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel  \ 
             | tee /dev/stderr \
             | xcbeautify --renderer github-actions --is-ci
 
-      - name: Generate code coverage report
-        if: steps.only_docs_changes.outputs.run == 'true'
-        run: ./scripts/utils/code-coverage.sh
+      # --enable-code-coverage
+      # - name: Generate code coverage report
+      #   if: steps.only_docs_changes.outputs.run == 'true'
+      #   run: ./scripts/utils/code-coverage.sh
 
   build_and_test_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/geko-pr.yml
+++ b/.github/workflows/geko-pr.yml
@@ -34,14 +34,13 @@ jobs:
         if: steps.only_docs_changes.outputs.run == 'true'
         run: |
           set -o pipefail
-          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test \
+          SWIFTPM_TEST_RUNNER_PROGRESS_BAR=lit xcrun swift test --parallel --enable-code-coverage \
             | tee /dev/stderr \
             | xcbeautify --renderer github-actions --is-ci
 
-      # --enable-code-coverage
-      # - name: Generate code coverage report
-      #   if: steps.only_docs_changes.outputs.run == 'true'
-      #   run: ./scripts/utils/code-coverage.sh
+      - name: Generate code coverage report
+        if: steps.only_docs_changes.outputs.run == 'true'
+        run: ./scripts/utils/code-coverage.sh
 
   build_and_test_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,14 @@ jobs:
           gh release create $TAG -d --title $TAG --notes "${{ env.CHANGELOG }}" --target $COMMIT_SHA build_artifacts/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy_docs:
+    name: Deploy documentation
+    needs: draft_release
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
+    with:
+      deploy: true

--- a/Package.swift
+++ b/Package.swift
@@ -379,6 +379,13 @@ var targets: [Target] = [
     ),
 
     // Test Targets
+    
+    .testTarget(
+        name: "AnyCodableTests",
+        dependencies: [
+            .byName(name: "AnyCodable")
+        ]
+    ),
 
     .testTarget(
         name: "GekoCacheAcceptanceTests",
@@ -418,6 +425,15 @@ var targets: [Target] = [
             "GekoCoreTesting",
             loggingDependency,
             .byName(name: "AnyCodable"),
+        ]
+    ),
+    .testTarget(
+        name: "GekoCloudTests",
+        dependencies: [
+            "GekoCloud",
+            "GekoCloudTesting",
+            "GekoSupportTesting",
+            "GekoCoreTesting",
         ]
     ),
     .testTarget(

--- a/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
+++ b/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
@@ -24,6 +24,8 @@ open class GekoAcceptanceTestCase: XCTestCase {
 
     private var derivedDataDirectory: TemporaryDirectory!
     private var fixtureTemporaryDirectory: TemporaryDirectory!
+    private var testSimulatorName: String?
+    private var testSimulatorUDID: String?
 
     override open func setUp() {
         super.setUp()
@@ -68,6 +70,11 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     override open func tearDown() async throws {
+        if let testSimulatorUDID {
+            try? System.shared.run(["/usr/bin/xcrun", "simctl", "delete", testSimulatorUDID])
+        }
+        testSimulatorName = nil
+        testSimulatorUDID = nil
         xcodeprojPath = nil
         workspacePath = nil
         fixturePath = nil
@@ -176,12 +183,44 @@ open class GekoAcceptanceTestCase: XCTestCase {
 
     public func run(_ command: TestCommand.Type, _ arguments: [String] = []) async throws {
         let arguments = arguments + [
+            "--device", try await isolatedTestSimulatorName(),
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
         ]
 
         let parsedCommand = try command.parse(arguments)
         try await parsedCommand.run()
+    }
+
+    public func run(_ command: TestCommand.Type, _ arguments: String...) async throws {
+        try await run(command, arguments)
+    }
+
+    private func isolatedTestSimulatorName() async throws -> String {
+        if let testSimulatorName {
+            return testSimulatorName
+        }
+
+        let sourceSimulator = try await SimulatorController().findAvailableDevice(
+            platform: .iOS,
+            version: nil,
+            minVersion: nil,
+            deviceName: nil
+        )
+        let deviceTypeIdentifier = try XCTUnwrap(sourceSimulator.device.deviceTypeIdentifier)
+        let name = "GekoAcceptanceTests-\(UUID().uuidString)"
+        let udid = try System.shared.capture([
+            "/usr/bin/xcrun",
+            "simctl",
+            "create",
+            name,
+            deviceTypeIdentifier,
+            sourceSimulator.runtime.identifier,
+        ]).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        testSimulatorName = name
+        testSimulatorUDID = udid
+        return name
     }
 
     public func run(_ command: BuildCommand.Type, _ arguments: [String] = []) async throws {

--- a/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
+++ b/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
@@ -35,6 +35,17 @@ open class GekoAcceptanceTestCase: XCTestCase {
         derivedDataDirectory = try! TemporaryDirectory(removeTreeOnDeinit: true)
         fixtureTemporaryDirectory = try! TemporaryDirectory(removeTreeOnDeinit: true)
 
+        setenv(
+            Constants.EnvironmentVariables.cocoapodsCacheDirectory.rawValue,
+            fixtureTemporaryDirectory.path.appending(component: "CocoapodsCache").pathString,
+            1
+        )
+        setenv(
+            Constants.EnvironmentVariables.cocoapodsRepoCacheDirectory.rawValue,
+            fixtureTemporaryDirectory.path.appending(component: "CocoapodsRepoCache").pathString,
+            1
+        )
+
         let sourceURL = URL(fileURLWithPath: #file).pathComponents
             .prefix(while: { $0 != "Sources" }).joined(separator: "/").dropFirst()
         

--- a/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
+++ b/Sources/GekoAcceptanceTesting/GekoAcceptanceTestCase.swift
@@ -24,8 +24,6 @@ open class GekoAcceptanceTestCase: XCTestCase {
 
     private var derivedDataDirectory: TemporaryDirectory!
     private var fixtureTemporaryDirectory: TemporaryDirectory!
-    private var testSimulatorName: String?
-    private var testSimulatorUDID: String?
 
     override open func setUp() {
         super.setUp()
@@ -70,11 +68,6 @@ open class GekoAcceptanceTestCase: XCTestCase {
     }
 
     override open func tearDown() async throws {
-        if let testSimulatorUDID {
-            try? System.shared.run(["/usr/bin/xcrun", "simctl", "delete", testSimulatorUDID])
-        }
-        testSimulatorName = nil
-        testSimulatorUDID = nil
         xcodeprojPath = nil
         workspacePath = nil
         fixturePath = nil
@@ -183,7 +176,6 @@ open class GekoAcceptanceTestCase: XCTestCase {
 
     public func run(_ command: TestCommand.Type, _ arguments: [String] = []) async throws {
         let arguments = arguments + [
-            "--device", try await isolatedTestSimulatorName(),
             "--derived-data-path", derivedDataPath.pathString,
             "--path", fixturePath.pathString,
         ]
@@ -194,33 +186,6 @@ open class GekoAcceptanceTestCase: XCTestCase {
 
     public func run(_ command: TestCommand.Type, _ arguments: String...) async throws {
         try await run(command, arguments)
-    }
-
-    private func isolatedTestSimulatorName() async throws -> String {
-        if let testSimulatorName {
-            return testSimulatorName
-        }
-
-        let sourceSimulator = try await SimulatorController().findAvailableDevice(
-            platform: .iOS,
-            version: nil,
-            minVersion: nil,
-            deviceName: nil
-        )
-        let deviceTypeIdentifier = try XCTUnwrap(sourceSimulator.device.deviceTypeIdentifier)
-        let name = "GekoAcceptanceTests-\(UUID().uuidString)"
-        let udid = try System.shared.capture([
-            "/usr/bin/xcrun",
-            "simctl",
-            "create",
-            name,
-            deviceTypeIdentifier,
-            sourceSimulator.runtime.identifier,
-        ]).trimmingCharacters(in: .whitespacesAndNewlines)
-
-        testSimulatorName = name
-        testSimulatorUDID = udid
-        return name
     }
 
     public func run(_ command: BuildCommand.Type, _ arguments: [String] = []) async throws {

--- a/Sources/GekoCloud/Services/AWSS3CacheCloudService.swift
+++ b/Sources/GekoCloud/Services/AWSS3CacheCloudService.swift
@@ -6,10 +6,10 @@ public final class AWSS3CacheCloudService: CacheCloudServicing {
 
     // MARK: - Attributes
 
-    private let awsService: AWSS3Service
+    private let awsService: AWSS3Servicing
     private let temporaryDir: TemporaryDirectory
     
-    public init(awsService: AWSS3Service) throws {
+    public init(awsService: AWSS3Servicing) throws {
         self.awsService = awsService
         self.temporaryDir = try TemporaryDirectory(removeTreeOnDeinit: true)
     }

--- a/Sources/GekoCloud/Services/CacheUploadService.swift
+++ b/Sources/GekoCloud/Services/CacheUploadService.swift
@@ -5,7 +5,7 @@ import GekoGraph
 import GekoLoader
 import GekoSupport
 
-enum CacheUploadError: FatalError {
+enum CacheUploadError: FatalError, Equatable {
     case cloudHasNotBeenConfigured
     case cloudInvalidURL(String)
 
@@ -38,11 +38,26 @@ public final class CacheUploadService {
 
     // MARK: - Initialization
 
-    public init() {
-        configLoader = ConfigLoader(manifestLoader: CompiledManifestLoader())
-        clock = WallClock()
-        timeTakenLoggerFormatter = TimeTakenLoggerFormatter()
-        fileArchiverFactory = FileArchivingFactory()
+    public convenience init() {
+        self.init(
+            configLoader: ConfigLoader(manifestLoader: CompiledManifestLoader()),
+            clock: WallClock(),
+            timeTakenLoggerFormatter: TimeTakenLoggerFormatter(),
+            fileArchiverFactory: FileArchivingFactory()
+        )
+    }
+
+    // Package initializer for testing
+    init(
+        configLoader: ConfigLoading,
+        clock: Clock,
+        timeTakenLoggerFormatter: TimeTakenLoggerFormatting,
+        fileArchiverFactory: FileArchivingFactorying
+    ) {
+        self.configLoader = configLoader
+        self.clock = clock
+        self.timeTakenLoggerFormatter = timeTakenLoggerFormatter
+        self.fileArchiverFactory = fileArchiverFactory
     }
 
     // MARK: - Service

--- a/Sources/GekoCloudTesting/Services/AWSS3ServiceMock.swift
+++ b/Sources/GekoCloudTesting/Services/AWSS3ServiceMock.swift
@@ -1,0 +1,20 @@
+import Foundation
+import GekoCloud
+import ProjectDescription
+
+public final class AWSS3ServiceMock: AWSS3Servicing {
+    public var checkExistsStub: ((String) async throws -> Bool)?
+    public func checkExists(key: String) async throws -> Bool {
+        return try await checkExistsStub!(key)
+    }
+    
+    public var downloadStub: ((String, String) async throws -> Void)?
+    public func download(key: String, fileName: String) async throws {
+        try await downloadStub!(key, fileName)
+    }
+    
+    public var uploadStub: ((ProjectDescription.AbsolutePath, String) async throws -> Void)?
+    public func upload(zipPath: ProjectDescription.AbsolutePath, key: String) async throws {
+        try await uploadStub!(zipPath, key)
+    }
+}

--- a/Sources/GekoSupport/System/System.swift
+++ b/Sources/GekoSupport/System/System.swift
@@ -220,12 +220,12 @@ public final class System: Systeming {
         )
         process.standardOutput = pipe
 
-        let inputFilePath = ".~input.temp"
-        var inputFile: FileHandle? = nil
+        var inputPipe: Pipe?
 
-        if let input {
-            inputFile = try inputFileForInput(input, atPath: inputFilePath)
-            process.standardInput = inputFile
+        if input != nil {
+            let pipe = Pipe()
+            inputPipe = pipe
+            process.standardInput = pipe
         }
 
         var result = Data()
@@ -243,10 +243,15 @@ public final class System: Systeming {
         }
 
         try process.run()
+
+        if let input, let inputPipe {
+            let inputWriter = inputPipe.fileHandleForWriting
+            defer { inputWriter.closeFile() }
+            try inputWriter.write(contentsOf: Data(input.utf8))
+        }
+
         process.waitUntilExit()
         group.wait()
-
-        if let inputFile { deleteInputFile(inputFile, atPath: inputFilePath) }
 
         return String(data: result, encoding: .utf8)!
     }
@@ -351,28 +356,6 @@ public final class System: Systeming {
     }
 
     // MARK: Helpers
-
-    private func deleteInputFile(_ fileHandle: FileHandle, atPath filePath: String) {
-        fileHandle.closeFile()
-        try? FileManager.default.removeItem(atPath: filePath)
-    }
-
-    private func inputFileForInput(_ input: String, atPath inputFilePath: String) throws -> FileHandle {
-        if FileManager.default.fileExists(atPath: inputFilePath) {
-            try FileManager.default.removeItem(atPath: inputFilePath)
-        }
-        guard FileManager.default.createFile(atPath: inputFilePath, contents: nil),
-              let inputData = input.data(using: .utf8),
-              let inputFile = FileHandle(forUpdatingAtPath: inputFilePath)
-        else {
-            throw SystemError.canNotCreateInputFile
-        }
-
-        try inputFile.seekToEnd()
-        try inputFile.write(contentsOf: inputData)
-        try inputFile.seek(toOffset: 0)
-        return inputFile
-    }
 
     /// Converts an array of arguments into a `Foundation.Process`
     /// - Parameters:

--- a/Sources/GekoSupportTesting/HTTP/MockFileClient.swift
+++ b/Sources/GekoSupportTesting/HTTP/MockFileClient.swift
@@ -45,8 +45,22 @@ public final class MockFileClient: FileClienting {
         stubbedDownloadEtagResult
     }
     
+    public var invokedCheckIfUrlIsReachable = false
+    public var invokedCheckIfUrlIsReachableCount = 0
+    public var invokedCheckIfUrlIsReachableParameters: URL?
+    public var invokedCheckIfUrlIsReachableParametersList = [URL]()
+    public var stubbedCheckIfUrlIsReachableResult = false
+    public var stubbedCheckIfUrlIsReachableError: Error!
+    
     public func checkIfUrlIsReachable(_ url: URL) async throws -> Bool {
-        return false
+        invokedCheckIfUrlIsReachable = true
+        invokedCheckIfUrlIsReachableCount += 1
+        invokedCheckIfUrlIsReachableParameters = url
+        invokedCheckIfUrlIsReachableParametersList.append(url)
+        if let stubbedCheckIfUrlIsReachableError {
+            throw stubbedCheckIfUrlIsReachableError
+        }
+        return stubbedCheckIfUrlIsReachableResult
     }
 }
 

--- a/Tests/AnyCodableTests/AnyCodableTests.swift
+++ b/Tests/AnyCodableTests/AnyCodableTests.swift
@@ -1,0 +1,151 @@
+// Copyright 2018 Read Evaluate Press, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+@testable import AnyCodable
+import XCTest
+
+class AnyCodableTests: XCTestCase {
+    
+    struct SomeCodable: Codable {
+        var string: String
+        var int: Int
+        var bool: Bool
+        var hasUnderscore: String
+        
+        enum CodingKeys: String,CodingKey {
+            case string
+            case int
+            case bool
+            case hasUnderscore = "has_underscore"
+        }
+    }
+    
+    func testJSONDecoding() throws {
+        let json = """
+        {
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": {
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            },
+            "null": null
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let dictionary = try decoder.decode([String: AnyCodable].self, from: json)
+
+        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+    }
+
+    func testJSONDecodingEquatable() throws {
+        let json = """
+        {
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": {
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            },
+            "null": null
+        }
+        """.data(using: .utf8)!
+        
+        let decoder = JSONDecoder()
+        let dictionary1 = try decoder.decode([String: AnyCodable].self, from: json)
+        let dictionary2 = try decoder.decode([String: AnyCodable].self, from: json)
+
+        XCTAssertEqual(dictionary1["boolean"], dictionary2["boolean"])
+        XCTAssertEqual(dictionary1["integer"], dictionary2["integer"])
+        XCTAssertEqual(dictionary1["double"], dictionary2["double"])
+        XCTAssertEqual(dictionary1["string"], dictionary2["string"])
+        XCTAssertEqual(dictionary1["array"], dictionary2["array"])
+        XCTAssertEqual(dictionary1["nested"], dictionary2["nested"])
+        XCTAssertEqual(dictionary1["null"], dictionary2["null"])
+    }
+
+    func testJSONEncoding() throws {
+        
+        let someCodable = AnyCodable(SomeCodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
+
+        let injectedValue = 1234
+        let dictionary: [String: AnyCodable] = [
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "stringInterpolation": "string \(injectedValue)",
+            "array": [1, 2, 3],
+            "nested": [
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie",
+            ],
+            "someCodable": someCodable,
+            "null": nil
+        ]
+
+        let encoder = JSONEncoder()
+
+        let json = try encoder.encode(dictionary)
+        let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+
+        let expected = """
+        {
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "stringInterpolation": "string 1234",
+            "array": [1, 2, 3],
+            "nested": {
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            },
+            "someCodable": {
+                "string":"String",
+                "int":100,
+                "bool": true,
+                "has_underscore":"another string"
+            },
+            "null": null
+        }
+        """.data(using: .utf8)!
+        let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+
+        XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    }
+}

--- a/Tests/AnyCodableTests/AnyDecodableTests.swift
+++ b/Tests/AnyCodableTests/AnyDecodableTests.swift
@@ -1,0 +1,53 @@
+// Copyright 2018 Read Evaluate Press, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+@testable import AnyCodable
+import XCTest
+
+class AnyDecodableTests: XCTestCase {
+    func testJSONDecoding() throws {
+        let json = """
+        {
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": {
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            },
+            "null": null
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let dictionary = try decoder.decode([String: AnyDecodable].self, from: json)
+
+        XCTAssertEqual(dictionary["boolean"]?.value as! Bool, true)
+        XCTAssertEqual(dictionary["integer"]?.value as! Int, 42)
+        XCTAssertEqual(dictionary["double"]?.value as! Double, 3.141592653589793, accuracy: 0.001)
+        XCTAssertEqual(dictionary["string"]?.value as! String, "string")
+        XCTAssertEqual(dictionary["array"]?.value as! [Int], [1, 2, 3])
+        XCTAssertEqual(dictionary["nested"]?.value as! [String: String], ["a": "alpha", "b": "bravo", "c": "charlie"])
+        XCTAssertEqual(dictionary["null"]?.value as! NSNull, NSNull())
+    }
+}

--- a/Tests/AnyCodableTests/AnyEncodableTests.swift
+++ b/Tests/AnyCodableTests/AnyEncodableTests.swift
@@ -1,0 +1,174 @@
+// Copyright 2018 Read Evaluate Press, LLC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+@testable import AnyCodable
+import XCTest
+
+class AnyEncodableTests: XCTestCase {
+    
+    struct SomeEncodable: Encodable {
+        var string: String
+        var int: Int
+        var bool: Bool
+        var hasUnderscore: String
+        
+        enum CodingKeys: String,CodingKey {
+            case string
+            case int
+            case bool
+            case hasUnderscore = "has_underscore"
+        }
+    }
+    
+    func testJSONEncoding() throws {
+        
+        let someEncodable = AnyEncodable(SomeEncodable(string: "String", int: 100, bool: true, hasUnderscore: "another string"))
+        
+        let dictionary: [String: AnyEncodable] = [
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": [
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie",
+            ],
+            "someCodable": someEncodable,
+            "null": nil
+        ]
+
+        let encoder = JSONEncoder()
+
+        let json = try encoder.encode(dictionary)
+        let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+
+        let expected = """
+        {
+            "boolean": true,
+            "integer": 42,
+            "double": 3.141592653589793,
+            "string": "string",
+            "array": [1, 2, 3],
+            "nested": {
+                "a": "alpha",
+                "b": "bravo",
+                "c": "charlie"
+            },
+            "someCodable": {
+                "string":"String",
+                "int":100,
+                "bool": true,
+                "has_underscore":"another string"
+            },
+            "null": null
+        }
+        """.data(using: .utf8)!
+        let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+
+        XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    }
+
+    func testEncodeNSNumber() throws {
+        let dictionary: [String: NSNumber] = [
+            "boolean": true,
+            "char": -127,
+            "int": -32767,
+            "short": -32767,
+            "long": -2147483647,
+            "longlong": -9223372036854775807,
+            "uchar": 255,
+            "uint": 65535,
+            "ushort": 65535,
+            "ulong": 4294967295,
+            "ulonglong": 18446744073709615,
+            "double": 3.141592653589793,
+        ]
+
+        let encoder = JSONEncoder()
+
+        let json = try encoder.encode(AnyEncodable(dictionary))
+        let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+
+        let expected = """
+        {
+            "boolean": true,
+            "char": -127,
+            "int": -32767,
+            "short": -32767,
+            "long": -2147483647,
+            "longlong": -9223372036854775807,
+            "uchar": 255,
+            "uint": 65535,
+            "ushort": 65535,
+            "ulong": 4294967295,
+            "ulonglong": 18446744073709615,
+            "double": 3.141592653589793,
+        }
+        """.data(using: .utf8)!
+        let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+
+        XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+        XCTAssert(encodedJSONObject["boolean"] is Bool)
+
+        XCTAssert(encodedJSONObject["char"] is Int8)
+        XCTAssert(encodedJSONObject["int"] is Int16)
+        XCTAssert(encodedJSONObject["short"] is Int32)
+        XCTAssert(encodedJSONObject["long"] is Int32)
+        XCTAssert(encodedJSONObject["longlong"] is Int64)
+
+        XCTAssert(encodedJSONObject["uchar"] is UInt8)
+        XCTAssert(encodedJSONObject["uint"] is UInt16)
+        XCTAssert(encodedJSONObject["ushort"] is UInt32)
+        XCTAssert(encodedJSONObject["ulong"] is UInt32)
+        XCTAssert(encodedJSONObject["ulonglong"] is UInt64)
+
+        XCTAssert(encodedJSONObject["double"] is Double)
+    }
+
+    func testStringInterpolationEncoding() throws {
+        let dictionary: [String: AnyEncodable] = [
+            "boolean": "\(true)",
+            "integer": "\(42)",
+            "double": "\(3.141592653589793)",
+            "string": "\("string")",
+            "array": "\([1, 2, 3])",
+        ]
+
+        let encoder = JSONEncoder()
+
+        let json = try encoder.encode(dictionary)
+        let encodedJSONObject = try JSONSerialization.jsonObject(with: json, options: []) as! NSDictionary
+
+        let expected = """
+        {
+            "boolean": "true",
+            "integer": "42",
+            "double": "3.141592653589793",
+            "string": "string",
+            "array": "[1, 2, 3]",
+        }
+        """.data(using: .utf8)!
+        let expectedJSONObject = try JSONSerialization.jsonObject(with: expected, options: []) as! NSDictionary
+
+        XCTAssertEqual(encodedJSONObject, expectedJSONObject)
+    }
+}

--- a/Tests/GekoCacheTests/Cache/CacheRemoteStorageTests.swift
+++ b/Tests/GekoCacheTests/Cache/CacheRemoteStorageTests.swift
@@ -170,7 +170,7 @@ final class CacheRemoteStorageTests: GekoUnitTestCase {
         _ = try await subject.fetch(name: targetName, hash: hash)
 
         // Then
-        XCTAssertFalse(fileUnarchiver.invokedUnzip)
+        XCTAssertTrue(fileUnarchiver.invokedUnzip)
     }
 
     // - store

--- a/Tests/GekoCacheTests/Cache/CacheRemoteStorageTests.swift
+++ b/Tests/GekoCacheTests/Cache/CacheRemoteStorageTests.swift
@@ -170,7 +170,7 @@ final class CacheRemoteStorageTests: GekoUnitTestCase {
         _ = try await subject.fetch(name: targetName, hash: hash)
 
         // Then
-        XCTAssertTrue(fileUnarchiver.invokedUnzip)
+        XCTAssertFalse(fileUnarchiver.invokedUnzip)
     }
 
     // - store

--- a/Tests/GekoCloudTests/AWSS3CacheCloudServiceTests.swift
+++ b/Tests/GekoCloudTests/AWSS3CacheCloudServiceTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import struct ProjectDescription.AbsolutePath
+import XCTest
+import GekoSupport
+import GekoCoreTesting
+
+@testable import GekoCloud
+@testable import GekoCloudTesting
+@testable import GekoSupportTesting
+
+final class AWSS3CacheCloudServiceTests: GekoUnitTestCase {
+    private var subject: AWSS3CacheCloudService!
+    private var mockAWSS3Service: AWSS3ServiceMock!
+    
+    override func setUpWithError() throws {
+        super.setUp()
+        mockAWSS3Service = AWSS3ServiceMock()
+        subject = try AWSS3CacheCloudService(awsService: mockAWSS3Service)
+    }
+    
+    override func tearDown() {
+        subject = nil
+        mockAWSS3Service = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_cacheExists_whenCacheExists_returnsTrue() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedKey = "/\(expectedName)/\(expectedContextFolder)/\(expectedHash).zip"
+        
+        mockAWSS3Service.checkExistsStub = { key in
+            XCTAssertEqual(key, expectedKey)
+            return true
+        }
+        
+        // When
+        let result = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+    func test_cacheExists_whenCacheNotExists_returnsFalse() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedKey = "/\(expectedName)/\(expectedContextFolder)/\(expectedHash).zip"
+        
+        mockAWSS3Service.checkExistsStub = { key in
+            XCTAssertEqual(key, expectedKey)
+            return false
+        }
+        
+        // When
+        let result = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertFalse(result)
+    }
+    
+    func test_download_returnsExpectedPath() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedKey = "/\(expectedName)/\(expectedContextFolder)/\(expectedHash).zip"
+        
+        var downloadedFilePath: String?
+        
+        mockAWSS3Service.downloadStub = { key, fileName in
+            XCTAssertEqual(key, expectedKey)
+            downloadedFilePath = fileName
+            
+            let fileHandler = FileHandler.shared
+            try fileHandler.write("dummy content", path: AbsolutePath(stringLiteral: fileName), atomically: true)
+        }
+        
+        // When
+        let resultPath = try await subject.download(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertNotNil(downloadedFilePath)
+        XCTAssertEqual(resultPath.pathString, downloadedFilePath)
+        XCTAssertTrue(FileHandler.shared.exists(resultPath))
+    }
+    
+    func test_download_generatesUniquePath() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        
+        mockAWSS3Service.downloadStub = { _, _ in
+            // Do nothing
+        }
+        
+        // When
+        let resultPath1 = try await subject.download(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        let resultPath2 = try await subject.download(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertNotEqual(resultPath1.pathString, resultPath2.pathString)
+    }
+    
+    func test_objectKey_format() async throws {
+        // Given
+        let expectedHash = "testHash"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Release"
+        let expectedKey = "/TestModule/Release/testHash.zip"
+        
+        mockAWSS3Service.checkExistsStub = { key in
+            XCTAssertEqual(key, expectedKey)
+            return true
+        }
+        
+        // When
+        let result = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+}

--- a/Tests/GekoCloudTests/CacheLatestPathStoreTests.swift
+++ b/Tests/GekoCloudTests/CacheLatestPathStoreTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import struct ProjectDescription.AbsolutePath
+import XCTest
+import GekoSupport
+import GekoCoreTesting
+
+@testable import GekoCloud
+@testable import GekoCloudTesting
+@testable import GekoSupportTesting
+
+final class CacheLatestPathStoreTests: GekoUnitTestCase {
+    private var subject: CacheLatestPathStore!
+    private var tempDir: AbsolutePath!
+    private var mockFileHandler: MockFileHandler!
+    private var mockCacheDirProvider: MockCacheDirectoriesProvider!
+    
+    override func setUpWithError() throws {
+        super.setUp()
+        tempDir = try temporaryPath()
+        mockFileHandler = MockFileHandler(temporaryDirectory: { self.tempDir })
+        mockCacheDirProvider = try MockCacheDirectoriesProvider()
+        mockCacheDirProvider.cacheDirectoryStub = tempDir
+        subject = CacheLatestPathStore(
+            fileHandler: mockFileHandler,
+            cacheDirectoriesProvider: mockCacheDirProvider
+        )
+    }
+    
+    override func tearDown() {
+        subject = nil
+        tempDir = nil
+        mockFileHandler = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_savelatestsPath_expectedResult() async throws {
+        // Given
+        let expectedPaths = [
+            AbsolutePath(stringLiteral: "foo/bar/alpha"),
+            AbsolutePath(stringLiteral: "foo/bar/beta"),
+            AbsolutePath(stringLiteral: "foo/bar/gamma")
+        ]
+        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
+        let expectedPath = tempDir.appending(components: ["BuildCache", "latest_build"])
+        
+        
+        mockFileHandler.stubWrite = { content, path, automatically in
+            XCTAssertEqual(path, expectedPath)
+            XCTAssertEqual(content, expectedContent)
+            XCTAssertTrue(automatically)
+        }
+        
+        // When
+        for path in expectedPaths {
+            await subject.store(hashFolder: path)
+        }
+        try await subject.save()
+    }
+    
+    func test_fetchLatestsPath_expectedResult() async throws {
+        // Given
+        let expectedPaths = [
+            AbsolutePath(stringLiteral: "foo/bar/alpha"),
+            AbsolutePath(stringLiteral: "foo/bar/beta"),
+            AbsolutePath(stringLiteral: "foo/bar/gamma")
+        ]
+        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
+        let expectedDirPath = tempDir.appending(components: ["BuildCache"])
+        let expectedFilePath = expectedDirPath.appending(components: ["latest_build"])
+        try mockFileHandler.createFolder(expectedDirPath)
+        try mockFileHandler.write(expectedContent, path: expectedFilePath, atomically: true)
+        
+        // When
+        let latestsPaths = try await subject.fetchLatest()
+        
+        // Then
+        XCTAssertEqual(expectedPaths, latestsPaths)
+    }
+}

--- a/Tests/GekoCloudTests/CredentialsProviderTests.swift
+++ b/Tests/GekoCloudTests/CredentialsProviderTests.swift
@@ -62,48 +62,4 @@ final class CredentialsProviderTests: GekoUnitTestCase {
         // Then
         XCTAssertTrue(result)
     }
-    
-//    func test_savelatestsPath_expectedResult() async throws {
-//        // Given
-//        let expectedPaths = [
-//            AbsolutePath(stringLiteral: "foo/bar/alpha"),
-//            AbsolutePath(stringLiteral: "foo/bar/beta"),
-//            AbsolutePath(stringLiteral: "foo/bar/gamma")
-//        ]
-//        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
-//        let expectedPath = tempDir.appending(components: ["BuildCache", "latest_build"])
-//        
-//        
-//        mockFileHandler.stubWrite = { content, path, automatically in
-//            XCTAssertEqual(path, expectedPath)
-//            XCTAssertEqual(content, expectedContent)
-//            XCTAssertTrue(automatically)
-//        }
-//        
-//        // When
-//        for path in expectedPaths {
-//            await subject.store(hashFolder: path)
-//        }
-//        try await subject.save()
-//    }
-//    
-//    func test_fetchLatestsPath_expectedResult() async throws {
-//        // Given
-//        let expectedPaths = [
-//            AbsolutePath(stringLiteral: "foo/bar/alpha"),
-//            AbsolutePath(stringLiteral: "foo/bar/beta"),
-//            AbsolutePath(stringLiteral: "foo/bar/gamma")
-//        ]
-//        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
-//        let expectedDirPath = tempDir.appending(components: ["BuildCache"])
-//        let expectedFilePath = expectedDirPath.appending(components: ["latest_build"])
-//        try mockFileHandler.createFolder(expectedDirPath)
-//        try mockFileHandler.write(expectedContent, path: expectedFilePath, atomically: true)
-//        
-//        // When
-//        let latestsPaths = try await subject.fetchLatest()
-//        
-//        // Then
-//        XCTAssertEqual(expectedPaths, latestsPaths)
-//    }
 }

--- a/Tests/GekoCloudTests/CredentialsProviderTests.swift
+++ b/Tests/GekoCloudTests/CredentialsProviderTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import struct ProjectDescription.AbsolutePath
+import XCTest
+import GekoSupport
+import GekoCoreTesting
+
+@testable import GekoCloud
+@testable import GekoCloudTesting
+@testable import GekoSupportTesting
+
+final class CredentialsProviderTests: GekoUnitTestCase {
+    private var subject: CredentialsProvider!
+    private var stubEnvs: [String: String]!
+    
+    override func setUp() {
+        super.setUp()
+        stubEnvs = [:]
+        subject = CredentialsProvider(environmentVariables: { self.stubEnvs })
+    }
+    
+    override func tearDown() {
+        subject = nil
+        stubEnvs = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests
+    
+    func test_credentialProvider_error() throws {
+        XCTAssertThrowsSpecific(try subject.providerCredentials(), CredentialsProviderError.credentialsNotFound)
+    }
+    
+    func test_isCredentialSetup_false() {
+        XCTAssertFalse(subject.isCredentialsSetup())
+    }
+    
+    func test_credentialProvider_correctSetup() throws {
+        // Given
+        let expectedAccessKey = "accessKey"
+        let expectedSecretKey = "secretKey"
+        stubEnvs[Constants.EnvironmentVariables.cloudAccessKey] = expectedAccessKey
+        stubEnvs[Constants.EnvironmentVariables.cloudSecretKey] = expectedSecretKey
+        
+        // When
+        let creds = try subject.providerCredentials()
+        
+        // Then
+        XCTAssertEqual(creds.accessKey, expectedAccessKey)
+        XCTAssertEqual(creds.secretKey, expectedSecretKey)
+    }
+    
+    func test_isCredentialSetup_true() throws {
+        // Given
+        let expectedAccessKey = "accessKey"
+        let expectedSecretKey = "secretKey"
+        stubEnvs[Constants.EnvironmentVariables.cloudAccessKey] = expectedAccessKey
+        stubEnvs[Constants.EnvironmentVariables.cloudSecretKey] = expectedSecretKey
+        
+        // When
+        let result = subject.isCredentialsSetup()
+        
+        // Then
+        XCTAssertTrue(result)
+    }
+    
+//    func test_savelatestsPath_expectedResult() async throws {
+//        // Given
+//        let expectedPaths = [
+//            AbsolutePath(stringLiteral: "foo/bar/alpha"),
+//            AbsolutePath(stringLiteral: "foo/bar/beta"),
+//            AbsolutePath(stringLiteral: "foo/bar/gamma")
+//        ]
+//        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
+//        let expectedPath = tempDir.appending(components: ["BuildCache", "latest_build"])
+//        
+//        
+//        mockFileHandler.stubWrite = { content, path, automatically in
+//            XCTAssertEqual(path, expectedPath)
+//            XCTAssertEqual(content, expectedContent)
+//            XCTAssertTrue(automatically)
+//        }
+//        
+//        // When
+//        for path in expectedPaths {
+//            await subject.store(hashFolder: path)
+//        }
+//        try await subject.save()
+//    }
+//    
+//    func test_fetchLatestsPath_expectedResult() async throws {
+//        // Given
+//        let expectedPaths = [
+//            AbsolutePath(stringLiteral: "foo/bar/alpha"),
+//            AbsolutePath(stringLiteral: "foo/bar/beta"),
+//            AbsolutePath(stringLiteral: "foo/bar/gamma")
+//        ]
+//        let expectedContent = expectedPaths.map(\.pathString).joined(separator: "\n")
+//        let expectedDirPath = tempDir.appending(components: ["BuildCache"])
+//        let expectedFilePath = expectedDirPath.appending(components: ["latest_build"])
+//        try mockFileHandler.createFolder(expectedDirPath)
+//        try mockFileHandler.write(expectedContent, path: expectedFilePath, atomically: true)
+//        
+//        // When
+//        let latestsPaths = try await subject.fetchLatest()
+//        
+//        // Then
+//        XCTAssertEqual(expectedPaths, latestsPaths)
+//    }
+}

--- a/Tests/GekoCloudTests/DirectCacheCloudServiceTests.swift
+++ b/Tests/GekoCloudTests/DirectCacheCloudServiceTests.swift
@@ -30,7 +30,7 @@ final class DirectCacheCloudServiceTests: GekoUnitTestCase {
         super.tearDown()
     }
     
-    // MARK: - Tests: cacheExists
+    // MARK: - Tests
     
     func test_cacheExists_whenCacheExists_returnsTrue() async throws {
         // Given
@@ -102,7 +102,7 @@ final class DirectCacheCloudServiceTests: GekoUnitTestCase {
         )
     }
     
-    // MARK: - Tests: download
+    // MARK: - Tests
     
     func test_download_returnsExpectedPath() async throws {
         // Given

--- a/Tests/GekoCloudTests/DirectCacheCloudServiceTests.swift
+++ b/Tests/GekoCloudTests/DirectCacheCloudServiceTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import struct ProjectDescription.AbsolutePath
+import XCTest
+import GekoSupport
+import GekoCoreTesting
+
+@testable import GekoCloud
+@testable import GekoSupportTesting
+
+final class DirectCacheCloudServiceTests: GekoUnitTestCase {
+    private var subject: DirectCacheCloudService!
+    private var mockFileClient: MockFileClient!
+    
+    private let testCloudURL = URL(string: "https://s3.example.com")!
+    private let testBucket = "test-bucket"
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockFileClient = MockFileClient()
+        subject = DirectCacheCloudService(
+            cloud: testCloudURL,
+            bucket: testBucket,
+            fileClient: mockFileClient
+        )
+    }
+    
+    override func tearDown() {
+        subject = nil
+        mockFileClient = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Tests: cacheExists
+    
+    func test_cacheExists_whenCacheExists_returnsTrue() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedURL = expectedUrl(
+            name: expectedName,
+            hash: expectedHash,
+            contextFolder: expectedContextFolder
+        )
+        
+        mockFileClient.stubbedCheckIfUrlIsReachableResult = true
+        
+        // When
+        let result = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertEqual(mockFileClient.invokedCheckIfUrlIsReachableParameters, expectedURL)
+    }
+    
+    func test_cacheExists_whenCacheNotExists_returnsFalse() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedURL = expectedUrl(
+            name: expectedName,
+            hash: expectedHash,
+            contextFolder: expectedContextFolder
+        )
+        
+        mockFileClient.stubbedCheckIfUrlIsReachableResult = false
+        
+        // When
+        let result = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertEqual(mockFileClient.invokedCheckIfUrlIsReachableParameters, expectedURL)
+    }
+    
+    func test_cacheExists_whenErrorIsThrown_propagatesError() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        
+        struct TestError: Error, Equatable {}
+        mockFileClient.stubbedCheckIfUrlIsReachableError = TestError()
+        
+        // When / Then
+        await XCTAssertThrowsSpecific(
+            try await subject.cacheExists(
+                hash: expectedHash,
+                name: expectedName,
+                contextFolder: expectedContextFolder
+            ),
+            TestError()
+        )
+    }
+    
+    // MARK: - Tests: download
+    
+    func test_download_returnsExpectedPath() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedURL = expectedUrl(
+            name: expectedName,
+            hash: expectedHash,
+            contextFolder: expectedContextFolder
+        )
+        let expectedPath = try temporaryPath().appending(component: "downloaded.zip")
+        try fileHandler.touch(expectedPath)
+        
+        mockFileClient.stubbedDownloadResult = expectedPath
+        
+        // When
+        let resultPath = try await subject.download(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertEqual(resultPath, expectedPath)
+        XCTAssertEqual(mockFileClient.invokedDownloadParameters?.url, expectedURL)
+    }
+    
+    func test_download_invokesFileClient() async throws {
+        // Given
+        let expectedHash = "abc123"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Debug"
+        let expectedURL = expectedUrl(
+            name: expectedName,
+            hash: expectedHash,
+            contextFolder: expectedContextFolder
+        )
+        let expectedPath = try temporaryPath().appending(component: "downloaded.zip")
+        try fileHandler.touch(expectedPath)
+        
+        mockFileClient.stubbedDownloadResult = expectedPath
+        
+        // When
+        _ = try await subject.download(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertTrue(mockFileClient.invokedDownload)
+        XCTAssertEqual(mockFileClient.invokedDownloadCount, 1)
+        XCTAssertEqual(mockFileClient.invokedDownloadParameters?.url, expectedURL)
+    }
+    
+    // MARK: - Tests: objectUrl format
+    
+    func test_objectUrl_format() async throws {
+        // Given
+        let expectedHash = "testHash"
+        let expectedName = "TestModule"
+        let expectedContextFolder = "Release"
+        let expectedURL = URL(string: "https://s3.example.com/test-bucket/TestModule/Release/testHash.zip")!
+        
+        mockFileClient.stubbedCheckIfUrlIsReachableResult = true
+        
+        // When
+        _ = try await subject.cacheExists(
+            hash: expectedHash,
+            name: expectedName,
+            contextFolder: expectedContextFolder
+        )
+        
+        // Then
+        XCTAssertEqual(mockFileClient.invokedCheckIfUrlIsReachableParameters, expectedURL)
+    }
+    
+    func test_objectUrl_withDifferentContexts() async throws {
+        // Given
+        let hash = "hash123"
+        let name = "MyTarget"
+        
+        let testCases: [(contextFolder: String, expectedURL: URL)] = [
+            ("Debug", URL(string: "https://s3.example.com/test-bucket/MyTarget/Debug/hash123.zip")!),
+            ("Release", URL(string: "https://s3.example.com/test-bucket/MyTarget/Release/hash123.zip")!),
+            ("Debug-arm64", URL(string: "https://s3.example.com/test-bucket/MyTarget/Debug-arm64/hash123.zip")!)
+        ]
+        
+        mockFileClient.stubbedCheckIfUrlIsReachableResult = true
+        
+        for testCase in testCases {
+            // Reset invocation tracking
+            mockFileClient.invokedCheckIfUrlIsReachable = false
+            mockFileClient.invokedCheckIfUrlIsReachableParameters = nil
+            
+            // When
+            _ = try await subject.cacheExists(
+                hash: hash,
+                name: name,
+                contextFolder: testCase.contextFolder
+            )
+            
+            // Then
+            XCTAssertEqual(
+                mockFileClient.invokedCheckIfUrlIsReachableParameters,
+                testCase.expectedURL,
+                "Failed for context folder: \(testCase.contextFolder)"
+            )
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func expectedUrl(name: String, hash: String, contextFolder: String) -> URL {
+        return testCloudURL
+            .appending(path: testBucket)
+            .appending(path: "/\(name)/\(contextFolder)/\(hash).zip")
+    }
+}

--- a/Tests/GekoSupportIntegrationTests/System/SystemIntegrationTests.swift
+++ b/Tests/GekoSupportIntegrationTests/System/SystemIntegrationTests.swift
@@ -28,6 +28,28 @@ final class SystemIntegrationTests: GekoTestCase {
         XCTAssertThrowsError(try subject.run(["ls", "abcdefghi"]))
     }
 
+    func test_capture_with_input_is_isolated_between_concurrent_processes() async throws {
+        let inputs = (0..<20).map { index in
+            String(repeating: "input-\(index)\n", count: 1000)
+        }
+
+        let outputs = try await withThrowingTaskGroup(of: (Int, String).self) { group in
+            for (index, input) in inputs.enumerated() {
+                group.addTask {
+                    (index, try System().capture(["/bin/cat"], withInput: input))
+                }
+            }
+
+            var outputs = Array(repeating: "", count: inputs.count)
+            for try await (index, output) in group {
+                outputs[index] = output
+            }
+            return outputs
+        }
+
+        XCTAssertEqual(outputs, inputs)
+    }
+
     func sandbox(_ name: String, value: String, do block: () throws -> Void) rethrows {
         try? ProcessEnv.setVar(name, value: value)
         _ = try? block()

--- a/Tests/GekoTestAcceptanceTests/TestAcceptanceTests.swift
+++ b/Tests/GekoTestAcceptanceTests/TestAcceptanceTests.swift
@@ -7,14 +7,11 @@ import XCTest
 final class TestAcceptanceTests: GekoAcceptanceTestCase {
     func test_with_app_with_framework_and_tests() async throws {
         try setUpFixture(.appWithFrameworkAndTests)
-        try await run(TestCommand.self)
-        try await run(TestCommand.self, "App")
         try await run(TestCommand.self, "--test-targets", "FrameworkTests/FrameworkTests")
     }
 
     func test_with_app_with_test_plan() async throws {
         try setUpFixture(.appWithTestPlan)
-        try await run(TestCommand.self)
         try await run(TestCommand.self, "App", "--test-plan", "All")
     }
 }

--- a/docs/guides/commands/clean.md
+++ b/docs/guides/commands/clean.md
@@ -3,7 +3,6 @@ title: Clean
 order: 1
 ---
 
-
 # geko clean
 
 Description of the geko clean command and how to use it.

--- a/scripts/utils/code-coverage.sh
+++ b/scripts/utils/code-coverage.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-#!/usr/bin/env bash
-
 set -euo pipefail
 
 ROOT_PATH="${GITHUB_WORKSPACE}"

--- a/scripts/utils/code-coverage.sh
+++ b/scripts/utils/code-coverage.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_PATH="${GITHUB_WORKSPACE}"
+BIN_PATH="$(xcrun swift build --show-bin-path)"
+PROFDATA_PATH="$(find "${BIN_PATH}" -type f -name '*.profdata' -print -quit)"
+
+XCTEST_PATH="$(
+  find "${BIN_PATH}" \
+    -maxdepth 2 \
+    -name '*PackageTests.xctest' \
+    -print \
+    -quit
+)"
+
+if [[ -z "${PROFDATA_PATH}" ]]; then
+  echo "Coverage profile was not found"
+  exit 1
+fi
+
+if [[ -z "${XCTEST_PATH}" ]]; then
+  echo "Test bundle was not found"
+  exit 1
+fi
+
+TEST_BINARY_NAME="$(basename "${XCTEST_PATH}" .xctest)"
+TEST_BINARY="${XCTEST_PATH}/Contents/MacOS/${TEST_BINARY_NAME}"
+
+if [[ ! -f "${TEST_BINARY}" ]]; then
+  echo "Test binary was not found: ${TEST_BINARY}"
+  exit 1
+fi
+
+echo "Test binary: ${TEST_BINARY}"
+echo "Coverage profile: ${PROFDATA_PATH}"
+
+PRODUCTION_SOURCES=()
+
+while IFS= read -r -d '' source_file; do
+  PRODUCTION_SOURCES+=("${source_file}")
+done < <(
+  find "${ROOT_PATH}/Sources" \
+    -type d \
+    -name '*Testing' \
+    -prune \
+    -o \
+    -type f \
+    -name '*.swift' \
+    -print0
+)
+
+if [[ ${#PRODUCTION_SOURCES[@]} -eq 0 ]]; then
+  echo "Production Swift sources were not found"
+  exit 1
+fi
+
+echo "Production source files: ${#PRODUCTION_SOURCES[@]}"
+
+COVERAGE_DIRECTORY="${ROOT_PATH}/coverage"
+COVERAGE_REPORT_PATH="${COVERAGE_DIRECTORY}/coverage-report.txt"
+
+mkdir -p "${COVERAGE_DIRECTORY}"
+
+xcrun llvm-cov report \
+  "${TEST_BINARY}" \
+  -instr-profile="${PROFDATA_PATH}" \
+  -show-branch-summary=false \
+  "${PRODUCTION_SOURCES[@]}" \
+  | tee "${COVERAGE_REPORT_PATH}"
+
+COVERAGE_SUMMARY="$(
+  awk '
+    NR <= 2 {
+      print
+      next
+    }
+
+    $1 == "TOTAL" {
+      print
+      exit
+    }
+  ' "${COVERAGE_REPORT_PATH}"
+)"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "## Code coverage"
+    echo
+    echo "Coverage includes production Swift files from \`Sources\`."
+    echo
+    echo "The following files are excluded:"
+    echo
+    echo "- targets whose directory name ends with \`Testing\`"
+    echo "- all files under \`Tests\`"
+    echo
+    echo '```text'
+    echo "${COVERAGE_SUMMARY}"
+    echo '```'
+    echo
+    echo "Full report: \`coverage/coverage-report.txt\`"
+  } >> "${GITHUB_STEP_SUMMARY}"
+
+  echo "Coverage was added to GitHub Actions summary"
+fi


### PR DESCRIPTION
## Description

I worked on several areas:

* First of all, I added code coverage collection for pull requests. Enabling code coverage does not have any noticeable impact on build times.
* I enabled parallel test execution and fixed the issues that had previously prevented us from using it.
  * This reduced the full PR test run from roughly 35–60 minutes to around 15–22 minutes. The results vary because GitHub’s free runners can differ significantly in performance.
* I reduced the number of acceptance test cases for the `geko tests` command to speed them up a bit.
* I fixed an issue with the malformed `input.temp` file generated when running `pod ipc spec repl`. [Check It](https://github.com/geko-tech/geko/pull/116/changes#diff-69af4006dc39d13488dbcdbae938276866a8c4f2eaf78043c7dead9d5214934f)
* I added tests for previously uncovered parts of the codebase.
* I moved documentation publishing to the release publishing stage. This is better than exposing documentation for functionality that has not actually been released yet.


## Motivation and Context

* Get information about code coverage 
* Reduce PR test run

## How Has This Been Tested?

### Testing

* Tested the changes through multiple CI runs in this pull request.
* Ran the full test suite locally.
* For the documentation publishing changes, I only ran the linter. We’ll test the actual publishing flow in production.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.