### PR TITLE
Geko [patch] Prevent graph traversal stack overflows

### DIFF
--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -78,9 +78,8 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
     private struct XCFrameworkDependenciesFrame {
         let path: AbsolutePath
         let dependency: GraphDependency
-        let directDependencies: [GraphDependency]
-        var nextDependencyIndex: Int
-        var result: Set<GraphDependency>
+        let directDependencies: Set<GraphDependency>
+        var preOrderVisit: Bool
     }
 
     // MARK: - Attributes
@@ -394,15 +393,13 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             return
         }
 
-        let rootDependencies = Array(graph.dependencies[graphDependency] ?? [])
-        var activePaths = Set([dependencyPath])
+        var activePaths = Set<AbsolutePath>()
         var stack = [
             XCFrameworkDependenciesFrame(
                 path: dependencyPath,
                 dependency: graphDependency,
-                directDependencies: rootDependencies,
-                nextDependencyIndex: 0,
-                result: Set(rootDependencies)
+                directDependencies: graph.dependencies[graphDependency] ?? [],
+                preOrderVisit: true
             ),
         ]
 
@@ -410,52 +407,40 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.directDependencies.count {
-                let dependency = frame.directDependencies[frame.nextDependencyIndex]
-                guard case let .xcframework(xcframework) = dependency else {
-                    stack[frameIndex].nextDependencyIndex += 1
+            if frame.preOrderVisit {
+                guard
+                    visitedNodes[frame.path] == nil,
+                    activePaths.insert(frame.path).inserted
+                else {
+                    stack.removeLast()
                     continue
                 }
 
-                if let cachedDependencies = visitedNodes[xcframework.path]?.1 {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].result.formUnion(cachedDependencies)
-                    continue
-                }
+                stack[frameIndex].preOrderVisit = false
 
-                if activePaths.contains(xcframework.path) {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
+                for case let .xcframework(xcframework) in frame.directDependencies {
+                    guard let childDependency = graph.xcframeworks[xcframework.path] else {
+                        continue
+                    }
 
-                guard let childDependency = graph.xcframeworks[xcframework.path] else {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
-
-                let childDependencies = Array(graph.dependencies[childDependency] ?? [])
-                activePaths.insert(xcframework.path)
-                stack.append(
-                    XCFrameworkDependenciesFrame(
-                        path: xcframework.path,
-                        dependency: childDependency,
-                        directDependencies: childDependencies,
-                        nextDependencyIndex: 0,
-                        result: Set(childDependencies)
+                    stack.append(
+                        XCFrameworkDependenciesFrame(
+                            path: xcframework.path,
+                            dependency: childDependency,
+                            directDependencies: graph.dependencies[childDependency] ?? [],
+                            preOrderVisit: true
+                        )
                     )
-                )
-            } else {
-                let completedFrame = stack.removeLast()
-                visitedNodes[completedFrame.path] = (
-                    completedFrame.dependency,
-                    completedFrame.result
-                )
-                activePaths.remove(completedFrame.path)
-
-                if let parentFrameIndex = stack.indices.last {
-                    stack[parentFrameIndex].nextDependencyIndex += 1
-                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
                 }
+            } else {
+                var dependencies = frame.directDependencies
+                for case let .xcframework(xcframework) in frame.directDependencies {
+                    dependencies.formUnion(visitedNodes[xcframework.path]?.1 ?? [])
+                }
+
+                visitedNodes[frame.path] = (frame.dependency, dependencies)
+                activePaths.remove(frame.path)
+                stack.removeLast()
             }
         }
     }

--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -75,6 +75,14 @@ public protocol SwiftModulesBuilding {
 }
 
 public final class SwiftModulesBuilder: SwiftModulesBuilding {
+    private struct XCFrameworkDependenciesFrame {
+        let path: AbsolutePath
+        let dependency: GraphDependency
+        let directDependencies: [GraphDependency]
+        var nextDependencyIndex: Int
+        var result: Set<GraphDependency>
+    }
+
     // MARK: - Attributes
     private let xcframeworkMetadataProvider: XCFrameworkMetadataProviding
     private let swiftinterfaceMetadataProvider: SwiftInterfaceMetadataProviding
@@ -110,15 +118,10 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             }
         }
 
-        // XCFrawework with transitive dependencies
-        var xcframeworksDependencies = [AbsolutePath: (GraphDependency, Set<GraphDependency>)]()
-        for (path, _) in filteredXCFrameworks {
-            transitiveXCFrameworkDependencies(
-                dependencyPath: path,
-                graph: graph,
-                visitedNodes: &xcframeworksDependencies
-            )
-        }
+        let xcframeworksDependencies = transitiveXCFrameworkDependencies(
+            dependencyPaths: Array(filteredXCFrameworks.keys),
+            graph: graph
+        )
 
         // Parse all needed for build metadata
         for (platform, sdkPath) in sdks {
@@ -362,26 +365,99 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
         })
     }
 
-    /// Method will recursively find all transitive dependencies for the passed xcframeworks
+    /// Collects direct and transitive dependencies for every XCFramework
+    /// reachable from the supplied roots.
+    func transitiveXCFrameworkDependencies(
+        dependencyPaths: [AbsolutePath],
+        graph: Graph
+    ) -> [AbsolutePath: (GraphDependency, Set<GraphDependency>)] {
+        var result = [AbsolutePath: (GraphDependency, Set<GraphDependency>)]()
+        for dependencyPath in dependencyPaths {
+            transitiveXCFrameworkDependencies(
+                dependencyPath: dependencyPath,
+                graph: graph,
+                visitedNodes: &result
+            )
+        }
+        return result
+    }
+
     private func transitiveXCFrameworkDependencies(
         dependencyPath: AbsolutePath,
         graph: Graph,
         visitedNodes: inout [AbsolutePath: (GraphDependency, Set<GraphDependency>)]
     ) {
-        if visitedNodes[dependencyPath] != nil { return }
-        guard let graphDependency = graph.xcframeworks[dependencyPath] else { return }
-        let directDependencies = graph.dependencies[graphDependency] ?? []
-        let transitiveDependencies = directDependencies.reduce(into: Set<GraphDependency>()) { acc, graphDependency in
-            if case let .xcframework(xcframework) = graphDependency {
-                transitiveXCFrameworkDependencies(
-                    dependencyPath: xcframework.path,
-                    graph: graph,
-                    visitedNodes: &visitedNodes
+        guard
+            visitedNodes[dependencyPath] == nil,
+            let graphDependency = graph.xcframeworks[dependencyPath]
+        else {
+            return
+        }
+
+        let rootDependencies = Array(graph.dependencies[graphDependency] ?? [])
+        var activePaths = Set([dependencyPath])
+        var stack = [
+            XCFrameworkDependenciesFrame(
+                path: dependencyPath,
+                dependency: graphDependency,
+                directDependencies: rootDependencies,
+                nextDependencyIndex: 0,
+                result: Set(rootDependencies)
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.directDependencies.count {
+                let dependency = frame.directDependencies[frame.nextDependencyIndex]
+                guard case let .xcframework(xcframework) = dependency else {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                if let cachedDependencies = visitedNodes[xcframework.path]?.1 {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].result.formUnion(cachedDependencies)
+                    continue
+                }
+
+                if activePaths.contains(xcframework.path) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                guard let childDependency = graph.xcframeworks[xcframework.path] else {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                let childDependencies = Array(graph.dependencies[childDependency] ?? [])
+                activePaths.insert(xcframework.path)
+                stack.append(
+                    XCFrameworkDependenciesFrame(
+                        path: xcframework.path,
+                        dependency: childDependency,
+                        directDependencies: childDependencies,
+                        nextDependencyIndex: 0,
+                        result: Set(childDependencies)
+                    )
                 )
-                acc.formUnion(visitedNodes[xcframework.path]?.1 ?? [])
+            } else {
+                let completedFrame = stack.removeLast()
+                visitedNodes[completedFrame.path] = (
+                    completedFrame.dependency,
+                    completedFrame.result
+                )
+                activePaths.remove(completedFrame.path)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
+                }
             }
         }
-        visitedNodes[dependencyPath] = (graphDependency, directDependencies.union(transitiveDependencies))
     }
 
     private func parseSwiftInterface(

--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -75,13 +75,6 @@ public protocol SwiftModulesBuilding {
 }
 
 public final class SwiftModulesBuilder: SwiftModulesBuilding {
-    private struct XCFrameworkDependenciesFrame {
-        let path: AbsolutePath
-        let dependency: GraphDependency
-        let directDependencies: Set<GraphDependency>
-        var preOrderVisit: Bool
-    }
-
     // MARK: - Attributes
     private let xcframeworkMetadataProvider: XCFrameworkMetadataProviding
     private let swiftinterfaceMetadataProvider: SwiftInterfaceMetadataProviding
@@ -386,6 +379,13 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
         graph: Graph,
         visitedNodes: inout [AbsolutePath: (GraphDependency, Set<GraphDependency>)]
     ) {
+        struct XCFrameworkDependenciesFrame {
+            let path: AbsolutePath
+            let dependency: GraphDependency
+            let directDependencies: Set<GraphDependency>
+            var preOrderVisit: Bool
+        }
+
         guard
             visitedNodes[dependencyPath] == nil,
             let graphDependency = graph.xcframeworks[dependencyPath]

--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -393,7 +393,6 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             return
         }
 
-        var activePaths = Set<AbsolutePath>()
         var stack = [
             XCFrameworkDependenciesFrame(
                 path: dependencyPath,
@@ -408,14 +407,14 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             let frame = stack[frameIndex]
 
             if frame.preOrderVisit {
-                guard
-                    visitedNodes[frame.path] == nil,
-                    activePaths.insert(frame.path).inserted
-                else {
+                guard visitedNodes[frame.path] == nil else {
                     stack.removeLast()
                     continue
                 }
 
+                // Store an empty placeholder before visiting dependencies to avoid processing
+                // the same node again. The final result overwrites it in postorder.
+                visitedNodes[frame.path] = (frame.dependency, [])
                 stack[frameIndex].preOrderVisit = false
 
                 for case let .xcframework(xcframework) in frame.directDependencies {
@@ -439,7 +438,6 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
                 }
 
                 visitedNodes[frame.path] = (frame.dependency, dependencies)
-                activePaths.remove(frame.path)
                 stack.removeLast()
             }
         }

--- a/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
+++ b/Sources/GekoCache/Utilities/Builders/SwiftModulesBuilder.swift
@@ -110,10 +110,16 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             }
         }
 
-        let xcframeworksDependencies = transitiveXCFrameworkDependencies(
-            dependencyPaths: Array(filteredXCFrameworks.keys),
-            graph: graph
-        )
+        /// Collects direct and transitive dependencies for every XCFramework
+        /// reachable from the supplied roots.
+        var xcframeworksDependencies = [AbsolutePath: (GraphDependency, Set<GraphDependency>)]()
+        for dependencyPath in filteredXCFrameworks.keys {
+            transitiveXCFrameworkDependencies(
+                dependencyPath: dependencyPath,
+                graph: graph,
+                visitedNodes: &xcframeworksDependencies
+            )
+        }
 
         // Parse all needed for build metadata
         for (platform, sdkPath) in sdks {
@@ -357,35 +363,11 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
         })
     }
 
-    /// Collects direct and transitive dependencies for every XCFramework
-    /// reachable from the supplied roots.
     func transitiveXCFrameworkDependencies(
-        dependencyPaths: [AbsolutePath],
-        graph: Graph
-    ) -> [AbsolutePath: (GraphDependency, Set<GraphDependency>)] {
-        var result = [AbsolutePath: (GraphDependency, Set<GraphDependency>)]()
-        for dependencyPath in dependencyPaths {
-            transitiveXCFrameworkDependencies(
-                dependencyPath: dependencyPath,
-                graph: graph,
-                visitedNodes: &result
-            )
-        }
-        return result
-    }
-
-    private func transitiveXCFrameworkDependencies(
         dependencyPath: AbsolutePath,
         graph: Graph,
         visitedNodes: inout [AbsolutePath: (GraphDependency, Set<GraphDependency>)]
     ) {
-        struct XCFrameworkDependenciesFrame {
-            let path: AbsolutePath
-            let dependency: GraphDependency
-            let directDependencies: Set<GraphDependency>
-            var preOrderVisit: Bool
-        }
-
         guard
             visitedNodes[dependencyPath] == nil,
             let graphDependency = graph.xcframeworks[dependencyPath]
@@ -393,14 +375,12 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
             return
         }
 
-        var stack = [
-            XCFrameworkDependenciesFrame(
-                path: dependencyPath,
-                dependency: graphDependency,
-                directDependencies: graph.dependencies[graphDependency] ?? [],
-                preOrderVisit: true
-            ),
-        ]
+        var stack = [(
+            path: dependencyPath,
+            dependency: graphDependency,
+            directDependencies: graph.dependencies[graphDependency] ?? [],
+            preOrderVisit: true
+        )]
 
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
@@ -422,14 +402,12 @@ public final class SwiftModulesBuilder: SwiftModulesBuilding {
                         continue
                     }
 
-                    stack.append(
-                        XCFrameworkDependenciesFrame(
-                            path: xcframework.path,
-                            dependency: childDependency,
-                            directDependencies: graph.dependencies[childDependency] ?? [],
-                            preOrderVisit: true
-                        )
-                    )
+                    stack.append((
+                        path: xcframework.path,
+                        dependency: childDependency,
+                        directDependencies: graph.dependencies[childDependency] ?? [],
+                        preOrderVisit: true
+                    ))
                 }
             } else {
                 var dependencies = frame.directDependencies

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -122,12 +122,6 @@ public class GraphTraverser: GraphTraversing {
     private let allTargetDependenciesLock = NSLock()
 
     public func allTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTarget> {
-        struct DependencySetTraversalFrame {
-            let node: GraphDependency
-            let dependencies: Set<GraphDependency>
-            var preOrderVisit: Bool
-        }
-
         let targetGraphDependency = GraphDependency.target(name: name, path: path)
 
         allTargetDependenciesLock.lock()
@@ -144,14 +138,11 @@ public class GraphTraverser: GraphTraversing {
             }
         }
 
-        var activeDependencies = Set<GraphDependency>()
-        var stack = [
-            DependencySetTraversalFrame(
-                node: targetGraphDependency,
-                dependencies: graph.dependencies[targetGraphDependency] ?? [],
-                preOrderVisit: true
-            ),
-        ]
+        var stack = [(
+            node: targetGraphDependency,
+            dependencies: graph.dependencies[targetGraphDependency] ?? [],
+            preOrderVisit: true
+        )]
 
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
@@ -159,23 +150,21 @@ public class GraphTraverser: GraphTraversing {
 
             if frame.preOrderVisit {
                 guard
-                    allTargetDependenciesCache[frame.node] == nil,
-                    activeDependencies.insert(frame.node).inserted
+                    allTargetDependenciesCache[frame.node] == nil
                 else {
                     stack.removeLast()
                     continue
                 }
 
                 stack[frameIndex].preOrderVisit = false
+                allTargetDependenciesCache[frame.node] = []
 
                 for dependency in frame.dependencies {
-                    stack.append(
-                        DependencySetTraversalFrame(
-                            node: dependency,
-                            dependencies: graph.dependencies[dependency] ?? [],
-                            preOrderVisit: true
-                        )
-                    )
+                    stack.append((
+                        node: dependency,
+                        dependencies: graph.dependencies[dependency] ?? [],
+                        preOrderVisit: true
+                    ))
                 }
             } else {
                 var result = frame.dependencies
@@ -184,7 +173,6 @@ public class GraphTraverser: GraphTraversing {
                 }
 
                 allTargetDependenciesCache[frame.node] = result
-                activeDependencies.remove(frame.node)
                 stack.removeLast()
             }
         }
@@ -285,7 +273,7 @@ public class GraphTraverser: GraphTraversing {
         guard let target = graph.targets[path]?[name] else { return [] }
         guard target.supportsResources else { return [] }
         let targetGraphDependency: GraphDependency = .target(name: name, path: path)
-        
+
         let canHostResources: (GraphDependency) -> Bool = {
             switch $0 {
             case let .xcframework(xcframework):
@@ -298,20 +286,20 @@ public class GraphTraverser: GraphTraversing {
                 return self.target(from: $0)?.target.supportsResources == true
             }
         }
-        
+
         resourceBundleDependenciesLock.lock()
         if let cached = resourceBundleDependenciesCache[targetGraphDependency] {
             resourceBundleDependenciesLock.unlock()
             return cached
         }
         resourceBundleDependenciesLock.unlock()
-        
+
         let bundles: Set<GraphDependency> = bundlesSearch(
             rootDependency: targetGraphDependency,
             test: { isSpmTarget in !isSpmTarget },
             skip: canHostResources
         )
-        
+
         let spmBundles: Set<GraphDependency>
         if canDependencyEmbedBundles(dependency: targetGraphDependency) {
             spmBundles = bundlesSearch(
@@ -322,22 +310,22 @@ public class GraphTraverser: GraphTraversing {
         } else {
             spmBundles = []
         }
-        
+
         let result = Set(
             bundles.union(spmBundles)
                 .compactMap { dependencyReference(to: $0, from: .target(name: name, path: path)) }
         )
-        
+
         resourceBundleDependenciesLock.lock()
         resourceBundleDependenciesCache[targetGraphDependency] = result
         resourceBundleDependenciesLock.unlock()
-        
+
         return result
     }
-    
+
     private var resourceBundleDependenciesCache: [GraphDependency: Set<GraphDependencyReference>] = [:]
     private let resourceBundleDependenciesLock = NSLock()
-    
+
     private func bundlesSearch(
         rootDependency: GraphDependency,
         test: (_ isSpmTarget: Bool) -> Bool,
@@ -382,10 +370,10 @@ public class GraphTraverser: GraphTraversing {
                 stack.append((dependency, dependencyIsSpm))
             }
         }
-        
+
         return result
     }
-    
+
     public func target(from dependency: GraphDependency) -> GraphTarget? {
         guard case let GraphDependency.target(name, path, _) = dependency else {
             return nil
@@ -515,22 +503,15 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func searchablePathDependencies(path: AbsolutePath, name: String) throws -> Set<GraphDependencyReference> {
-        let deps = try linkableDependencies(
-            path: path,
-            name: name,
-            shouldExcludeNonLinkableDependencies: false
-        )
+        let deps = try linkableDependencies(path: path, name: name, shouldExcludeNonLinkableDependencies: false)
 
         if let target = target(path: path, name: name),
-           target.target.product == .unitTests || target.target.product == .uiTests,
-           let appHostTarget = unitTestHost(path: path, name: name)
+            target.target.product == .unitTests || target.target.product == .uiTests,
+            let appHostTarget = unitTestHost(path: path, name: name)
         {
             // Unit and UI tests can use the same dependencies as their host app without linking them.
             return deps.union(
-                try searchablePathDependencies(
-                    path: appHostTarget.path,
-                    name: appHostTarget.target.name
-                )
+                try searchablePathDependencies(path: appHostTarget.path, name: appHostTarget.target.name)
             )
         }
 
@@ -632,24 +613,15 @@ public class GraphTraverser: GraphTraversing {
 
     // WARNING: do not use without locking `linkableDependenciesSearchCacheLock` first
     private func linkableDependenciesSearch(from node: GraphDependency) -> Set<GraphDependency> {
-        struct DependencySetTraversalFrame {
-            let node: GraphDependency
-            let dependencies: Set<GraphDependency>
-            var preOrderVisit: Bool
-        }
-
         if let cached = linkableDependenciesSearchCache[node] {
             return cached
         }
 
-        var activeDependencies = Set<GraphDependency>()
-        var stack = [
-            DependencySetTraversalFrame(
-                node: node,
-                dependencies: graph.dependencies[node] ?? [],
-                preOrderVisit: true
-            ),
-        ]
+        var stack = [(
+            node: node,
+            dependencies: graph.dependencies[node] ?? [],
+            preOrderVisit: true
+        )]
 
         // Collect every transitive linkable dependency in postorder so child cache entries
         // are ready before their parents are finalized.
@@ -659,14 +631,17 @@ public class GraphTraverser: GraphTraversing {
 
             if frame.preOrderVisit {
                 guard
-                    linkableDependenciesSearchCache[frame.node] == nil,
-                    activeDependencies.insert(frame.node).inserted
+                    linkableDependenciesSearchCache[frame.node] == nil
                 else {
                     stack.removeLast()
                     continue
                 }
 
+                // Store an empty placeholder before visiting dependencies to avoid processing
+                // the same node again. The final result overwrites it in postorder.
+                linkableDependenciesSearchCache[frame.node] = []
                 stack[frameIndex].preOrderVisit = false
+
                 let appHostDependency = appHostDependency(for: frame.node)
 
                 for dependency in frame.dependencies {
@@ -675,13 +650,11 @@ public class GraphTraverser: GraphTraversing {
                         continue
                     }
 
-                    stack.append(
-                        DependencySetTraversalFrame(
-                            node: dependency,
-                            dependencies: graph.dependencies[dependency] ?? [],
-                            preOrderVisit: true
-                        )
-                    )
+                    stack.append((
+                        node: dependency,
+                        dependencies: graph.dependencies[dependency] ?? [],
+                        preOrderVisit: true
+                    ))
                 }
             } else {
                 var collectedDependencies = Set<GraphDependency>()
@@ -701,7 +674,6 @@ public class GraphTraverser: GraphTraversing {
                     directDependencies: frame.dependencies
                 )
                 linkableDependenciesSearchCache[frame.node] = collectedDependencies
-                activeDependencies.remove(frame.node)
                 stack.removeLast()
             }
         }
@@ -738,9 +710,8 @@ public class GraphTraverser: GraphTraversing {
         // dynamic framework, Framework1 should not be linked to App, because in such case
         // Framework1 will be linked two times to App and to dynamic framework
         for dependency in collectedDependencies {
-            guard canDependencyLinkStaticProducts(dependency: dependency) else {
-                continue
-            }
+            // process only dynamic dependencies
+            guard canDependencyLinkStaticProducts(dependency: dependency) else { continue }
 
             var searchResult = linkableDependenciesSearchCache[dependency] ?? []
             searchResult = searchResult.filter {
@@ -762,9 +733,7 @@ public class GraphTraverser: GraphTraversing {
         // so we walk through each static dependency and search for dynamic dependencies and sdks
         // (sdks are considered dynamic dependencies)
         for dependency in collectedDependencies {
-            guard isDependencyStatic(dependency: dependency) else {
-                continue
-            }
+            guard isDependencyStatic(dependency: dependency) else { continue }
 
             let searchResult = linkableDependenciesSearchCache[dependency] ?? []
             collectedDependencies.formUnion(searchResult.filter { isDependencyDynamic(dependency: $0) })
@@ -839,7 +808,7 @@ public class GraphTraverser: GraphTraversing {
     }
 
     private var allMacroTargetsCache: [GraphTarget: Set<GraphTarget>] = [:]
-    private var allMacroTargetsLock = NSRecursiveLock()
+    private var allMacroTargetsLock = NSLock()
 
     /// Returns linkable targets that directly depend on Swift macro targets, including those reached transitively.
     /// The macro targets themselves are not included.
@@ -859,7 +828,7 @@ public class GraphTraverser: GraphTraversing {
                         graphTraverser.directTargetDependencies(
                             path: target.path,
                             name: target.target.name
-                        ).map(\.graphTarget)
+                        ).map { $0.graphTarget }
                     ),
                     preOrderVisit: true
                 )
@@ -875,7 +844,6 @@ public class GraphTraverser: GraphTraversing {
             return cached
         }
 
-        var activeTargets = Set<GraphTarget>()
         var stack = [SwiftMacroTargetsTraversalFrame.make(for: target, graphTraverser: self)]
 
         while !stack.isEmpty {
@@ -883,15 +851,16 @@ public class GraphTraverser: GraphTraversing {
             let frame = stack[frameIndex]
 
             if frame.preOrderVisit {
-                guard
-                    allMacroTargetsCache[frame.target] == nil,
-                    activeTargets.insert(frame.target).inserted
-                else {
+                guard allMacroTargetsCache[frame.target] == nil else {
                     stack.removeLast()
                     continue
                 }
 
+                // Store an empty placeholder before visiting dependencies to avoid processing
+                // the same node again. The final result overwrites it in postorder.
+                allMacroTargetsCache[frame.target] = []
                 stack[frameIndex].preOrderVisit = false
+
                 for dependency in frame.dependencies {
                     stack.append(.make(for: dependency, graphTraverser: self))
                 }
@@ -906,7 +875,6 @@ public class GraphTraverser: GraphTraversing {
                 }
 
                 allMacroTargetsCache[frame.target] = result
-                activeTargets.remove(frame.target)
                 stack.removeLast()
             }
         }
@@ -1335,6 +1303,7 @@ public class GraphTraverser: GraphTraversing {
                 // the same node again. The final result overwrites it in postorder.
                 result[frame.node] = [:]
                 stack[frameIndex].preOrderVisit = false
+
                 for dependency in frame.dependencies {
                     stack.append(
                         ConditionMapTraversalFrame(
@@ -1373,7 +1342,6 @@ public class GraphTraverser: GraphTraversing {
                         // C should have `[.ios, .macos]` set for filters to satisfy both paths
                         nodeResult[transitiveDependency] = previousResult.combineWith(combinedCondition)
                     }
-
                 }
 
                 for dependency in frame.dependencies {
@@ -1396,32 +1364,28 @@ public class GraphTraverser: GraphTraversing {
             (target: $0, parentPlatforms: $0.target.supportedPlatforms)
         }
 
-        while let item = stack.popLast() {
-            let dependencies = directTargetDependencies(
-                path: item.target.path,
-                name: item.target.target.name
-            )
+        while let (target, parentPlatforms) = stack.popLast() {
+            let dependencies = directTargetDependencies(path: target.path, name: target.target.name)
 
             for dependencyTargetReference in dependencies {
                 var platformsToInsert: Set<Platform>?
                 let dependencyTarget = dependencyTargetReference.graphTarget
                 let inheritedPlatforms =
                     dependencyTarget.target.product == .macro
-                        ? Set<Platform>([.macOS]) : item.parentPlatforms
+                        ? Set<Platform>([.macOS]) : parentPlatforms
 
                 if let dependencyCondition = dependencyTargetReference.condition,
-                   let platformIntersection = PlatformCondition.when(item.target.target.dependencyPlatformFilters)?
-                       .intersection(dependencyCondition)
+                    let platformIntersection = PlatformCondition.when(target.target.dependencyPlatformFilters)?
+                        .intersection(dependencyCondition)
                 {
                     switch platformIntersection {
                     case .incompatible:
                         break
                     case let .condition(condition):
                         if let condition {
-                            platformsToInsert = Set(
-                                condition.platformFilters
-                                    .compactMap(\.platform)
-                            ).intersection(inheritedPlatforms)
+                            platformsToInsert = inheritedPlatforms.intersection(
+                                condition.platformFilters.compactMap(\.platform)
+                            )
                         }
                     }
                 } else {
@@ -1430,9 +1394,7 @@ public class GraphTraverser: GraphTraversing {
                     )
                 }
 
-                guard let platformsToInsert else {
-                    continue
-                }
+                guard let platformsToInsert else { continue }
 
                 var existingPlatforms = platforms[dependencyTarget, default: Set()]
                 let continueTraversing = !platformsToInsert.isSubset(of: existingPlatforms)

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -5,24 +5,6 @@ import ProjectDescription
 
 // swiftlint:disable type_body_length
 public class GraphTraverser: GraphTraversing {
-    private struct DependencySetTraversalFrame {
-        let node: GraphDependency
-        let dependencies: Set<GraphDependency>
-        var preOrderVisit: Bool
-    }
-
-    private struct ConditionMapTraversalFrame {
-        let node: GraphDependency
-        let dependencies: Set<GraphDependency>
-        var preOrderVisit: Bool
-    }
-
-    private struct SwiftMacroTargetsTraversalFrame {
-        let target: GraphTarget
-        let dependencies: Set<GraphTarget>
-        var preOrderVisit: Bool
-    }
-
     public var name: String { graph.name }
     public var path: AbsolutePath { graph.path }
     public var workspace: Workspace { graph.workspace }
@@ -140,6 +122,12 @@ public class GraphTraverser: GraphTraversing {
     private let allTargetDependenciesLock = NSLock()
 
     public func allTargetDependencies(path: AbsolutePath, name: String) -> Set<GraphTarget> {
+        struct DependencySetTraversalFrame {
+            let node: GraphDependency
+            let dependencies: Set<GraphDependency>
+            var preOrderVisit: Bool
+        }
+
         let targetGraphDependency = GraphDependency.target(name: name, path: path)
 
         allTargetDependenciesLock.lock()
@@ -652,6 +640,12 @@ public class GraphTraverser: GraphTraversing {
 
     // WARNING: do not use without locking `linkableDependenciesSearchCacheLock` first
     private func linkableDependenciesSearch(from node: GraphDependency) -> Set<GraphDependency> {
+        struct DependencySetTraversalFrame {
+            let node: GraphDependency
+            let dependencies: Set<GraphDependency>
+            var preOrderVisit: Bool
+        }
+
         if let cached = linkableDependenciesSearchCache[node] {
             return cached
         }
@@ -860,6 +854,28 @@ public class GraphTraverser: GraphTraversing {
     /// Returns linkable targets that directly depend on Swift macro targets, including those reached transitively.
     /// The macro targets themselves are not included.
     public func allSwiftMacroTargets(path: AbsolutePath, name: String) -> Set<GraphTarget> {
+        struct SwiftMacroTargetsTraversalFrame {
+            let target: GraphTarget
+            let dependencies: Set<GraphTarget>
+            var preOrderVisit: Bool
+
+            static func make(
+                for target: GraphTarget,
+                graphTraverser: GraphTraverser
+            ) -> SwiftMacroTargetsTraversalFrame {
+                SwiftMacroTargetsTraversalFrame(
+                    target: target,
+                    dependencies: Set(
+                        graphTraverser.directTargetDependencies(
+                            path: target.path,
+                            name: target.target.name
+                        ).map(\.graphTarget)
+                    ),
+                    preOrderVisit: true
+                )
+            }
+        }
+
         allMacroTargetsLock.lock()
         defer { allMacroTargetsLock.unlock() }
 
@@ -870,7 +886,7 @@ public class GraphTraverser: GraphTraversing {
         }
 
         var activeTargets = Set<GraphTarget>()
-        var stack = [swiftMacroTargetsTraversalFrame(for: target)]
+        var stack = [SwiftMacroTargetsTraversalFrame.make(for: target, graphTraverser: self)]
 
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
@@ -887,7 +903,7 @@ public class GraphTraverser: GraphTraversing {
 
                 stack[frameIndex].preOrderVisit = false
                 for dependency in frame.dependencies {
-                    stack.append(swiftMacroTargetsTraversalFrame(for: dependency))
+                    stack.append(.make(for: dependency, graphTraverser: self))
                 }
             } else {
                 var result = Set<GraphTarget>()
@@ -906,16 +922,6 @@ public class GraphTraverser: GraphTraversing {
         }
 
         return allMacroTargetsCache[target] ?? []
-    }
-
-    private func swiftMacroTargetsTraversalFrame(for target: GraphTarget) -> SwiftMacroTargetsTraversalFrame {
-        SwiftMacroTargetsTraversalFrame(
-            target: target,
-            dependencies: Set(
-                directTargetDependencies(path: target.path, name: target.target.name).map(\.graphTarget)
-            ),
-            preOrderVisit: true
-        )
     }
 
     private func isLinkableTargetWithDirectSwiftMacro(_ target: GraphTarget) -> Bool {
@@ -1308,6 +1314,12 @@ public class GraphTraverser: GraphTraversing {
     }
 
     private func calculateCombinedConditionMap() {
+        struct ConditionMapTraversalFrame {
+            let node: GraphDependency
+            let dependencies: Set<GraphDependency>
+            var preOrderVisit: Bool
+        }
+
         var result: [GraphDependency: [GraphDependency: PlatformCondition.CombinationResult]] = [:]
         var completedDependencies = Set<GraphDependency>()
 

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -5,6 +5,27 @@ import ProjectDescription
 
 // swiftlint:disable type_body_length
 public class GraphTraverser: GraphTraversing {
+    private struct DependencySetTraversalFrame {
+        let node: GraphDependency
+        let dependencies: [GraphDependency]
+        var nextDependencyIndex: Int
+        var result: Set<GraphDependency>
+    }
+
+    private struct ConditionMapTraversalFrame {
+        let node: GraphDependency
+        let dependencies: [GraphDependency]
+        var nextDependencyIndex: Int
+        var result: [GraphDependency: PlatformCondition.CombinationResult]
+    }
+
+    private struct SwiftMacroTargetsTraversalFrame {
+        let target: GraphTarget
+        let dependencies: [GraphTarget]
+        var nextDependencyIndex: Int
+        var result: Set<GraphTarget>
+    }
+
     public var name: String { graph.name }
     public var path: AbsolutePath { graph.path }
     public var workspace: Workspace { graph.workspace }
@@ -138,27 +159,56 @@ public class GraphTraverser: GraphTraversing {
             }
         }
 
-        func dfs(_ graphDependency: GraphDependency) {
-            if allTargetDependenciesCache[graphDependency] != nil {
-                return
+        let rootDependencies = Array(graph.dependencies[targetGraphDependency] ?? [])
+        var activeDependencies = Set([targetGraphDependency])
+        var stack = [
+            DependencySetTraversalFrame(
+                node: targetGraphDependency,
+                dependencies: rootDependencies,
+                nextDependencyIndex: 0,
+                result: Set(rootDependencies)
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let dependency = frame.dependencies[frame.nextDependencyIndex]
+
+                if let cachedDependencies = allTargetDependenciesCache[dependency] {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].result.formUnion(cachedDependencies)
+                    continue
+                }
+
+                if activeDependencies.contains(dependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                let dependencies = Array(graph.dependencies[dependency] ?? [])
+                activeDependencies.insert(dependency)
+                stack.append(
+                    DependencySetTraversalFrame(
+                        node: dependency,
+                        dependencies: dependencies,
+                        nextDependencyIndex: 0,
+                        result: Set(dependencies)
+                    )
+                )
+            } else {
+                let completedFrame = stack.removeLast()
+                allTargetDependenciesCache[completedFrame.node] = completedFrame.result
+                activeDependencies.remove(completedFrame.node)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
+                }
             }
-
-            guard let deps = graph.dependencies[graphDependency] else {
-                allTargetDependenciesCache[graphDependency] = []
-                return
-            }
-
-            allTargetDependenciesCache[graphDependency] = Set(deps)
-
-            for dep in deps {
-                dfs(dep)
-
-                allTargetDependenciesCache[graphDependency]!.formUnion(allTargetDependenciesCache[dep]!)
-            }
-
         }
-
-        dfs(targetGraphDependency)
 
         return allTargetDependenciesCache[targetGraphDependency]!.reduce(into: Set()) { result, dep in
             guard
@@ -316,7 +366,10 @@ public class GraphTraverser: GraphTraversing {
     ) -> Set<GraphDependency> {
         var visited: Set<GraphDependency> = []
         var result: Set<GraphDependency> = []
-        
+        var stack: [(dependency: GraphDependency, isParentSpmTarget: Bool)] = [
+            (rootDependency, false),
+        ]
+
         func isSpmTarget(dependency: GraphDependency, isParentSpmTarget: Bool) -> Bool {
             if let target = self.target(from: dependency) {
                 isParentSpmTarget || target.project.projectType == .spm
@@ -324,34 +377,32 @@ public class GraphTraverser: GraphTraversing {
                 isParentSpmTarget
             }
         }
-        
-        func dfs(_ dependency: GraphDependency, isParentSpmTarget: Bool) {
-            if visited.contains(dependency) {
-                return
+
+        while let item = stack.popLast() {
+            guard visited.insert(item.dependency).inserted else {
+                continue
             }
 
-            visited.insert(dependency)
-            
-            let isSpmTarget = isSpmTarget(dependency: dependency, isParentSpmTarget: isParentSpmTarget)
-            
-            if dependency != rootDependency && isDependencyResourceBundle(dependency: dependency) && test(isSpmTarget) {
-                result.insert(dependency)
+            let dependencyIsSpm = isSpmTarget(
+                dependency: item.dependency,
+                isParentSpmTarget: item.isParentSpmTarget
+            )
+
+            if item.dependency != rootDependency,
+               isDependencyResourceBundle(dependency: item.dependency),
+               test(dependencyIsSpm)
+            {
+                result.insert(item.dependency)
             }
-            
-            if dependency != rootDependency && skip(dependency) {
-                return
+
+            if item.dependency != rootDependency, skip(item.dependency) {
+                continue
             }
-            
-            guard let deps = self.graph.dependencies[dependency] else {
-                return
-            }
-            
-            for dep in deps {
-                dfs(dep, isParentSpmTarget: isSpmTarget)
+
+            for dependency in Array(graph.dependencies[item.dependency] ?? []).reversed() {
+                stack.append((dependency, dependencyIsSpm))
             }
         }
-        
-        dfs(rootDependency, isParentSpmTarget: false)
         
         return result
     }
@@ -485,19 +536,34 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func searchablePathDependencies(path: AbsolutePath, name: String) throws -> Set<GraphDependencyReference> {
-        let deps = try linkableDependencies(path: path, name: name, shouldExcludeNonLinkableDependencies: false)
+        var result = Set<GraphDependencyReference>()
+        var currentPath = path
+        var currentName = name
+        var visitedTargets = Set<GraphDependency>()
 
-        if let target = target(path: path, name: name),
-            target.target.product == .unitTests || target.target.product == .uiTests,
-            let appHostTarget = unitTestHost(path: path, name: name)
-        {
-            // unit and ui tests can use the same dependencies as in host app without linking them
-            return deps.union(
-                try searchablePathDependencies(path: appHostTarget.path, name: appHostTarget.target.name)
+        while visitedTargets.insert(.target(name: currentName, path: currentPath)).inserted {
+            result.formUnion(
+                try linkableDependencies(
+                    path: currentPath,
+                    name: currentName,
+                    shouldExcludeNonLinkableDependencies: false
+                )
             )
+
+            guard
+                let target = target(path: currentPath, name: currentName),
+                target.target.product == .unitTests || target.target.product == .uiTests,
+                let appHostTarget = unitTestHost(path: currentPath, name: currentName)
+            else {
+                break
+            }
+
+            // Unit and UI tests can use the same dependencies as their host app without linking them.
+            currentPath = appHostTarget.path
+            currentName = appHostTarget.target.name
         }
 
-        return deps
+        return result
     }
 
     public func linkableDependencies(path: AbsolutePath, name: String) throws -> Set<GraphDependencyReference> {
@@ -593,90 +659,139 @@ public class GraphTraverser: GraphTraversing {
     private var linkableDependenciesSearchCache: [GraphDependency: Set<GraphDependency>] = [:]
     private var linkableDependenciesSearchCacheLock = NSLock()
 
-    // helper that recursively searches for dependencies, that should be linked
     // WARNING: do not use without locking `linkableDependenciesSearchCacheLock` first
     private func linkableDependenciesSearch(from node: GraphDependency) -> Set<GraphDependency> {
         if let cached = linkableDependenciesSearchCache[node] {
             return cached
         }
 
-        var appHostDependency: GraphDependency? = nil
-        if
+        let directDependencies = Array(graph.dependencies[node] ?? [])
+        var activeDependencies = Set([node])
+        var stack = [
+            DependencySetTraversalFrame(
+                node: node,
+                dependencies: directDependencies,
+                nextDependencyIndex: 0,
+                result: []
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let dependency = frame.dependencies[frame.nextDependencyIndex]
+                let appHostDependency = appHostDependency(for: frame.node)
+
+                // Macro executables and other non-linkable dependencies are not part of the linking tree.
+                guard isDependencyLinkable(dependency: dependency) || dependency == appHostDependency else {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                stack[frameIndex].result.insert(dependency)
+
+                if let cachedDependencies = linkableDependenciesSearchCache[dependency] {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].result.formUnion(cachedDependencies)
+                    continue
+                }
+
+                if activeDependencies.contains(dependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                activeDependencies.insert(dependency)
+                stack.append(
+                    DependencySetTraversalFrame(
+                        node: dependency,
+                        dependencies: Array(graph.dependencies[dependency] ?? []),
+                        nextDependencyIndex: 0,
+                        result: []
+                    )
+                )
+            } else {
+                let completedFrame = stack.removeLast()
+                let result = finalizeLinkableDependencies(
+                    completedFrame.result,
+                    directDependencies: Set(completedFrame.dependencies)
+                )
+                linkableDependenciesSearchCache[completedFrame.node] = result
+                activeDependencies.remove(completedFrame.node)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].result.formUnion(result)
+                } else {
+                    return result
+                }
+            }
+        }
+
+        return linkableDependenciesSearchCache[node] ?? []
+    }
+
+    private func appHostDependency(for node: GraphDependency) -> GraphDependency? {
+        guard
             case let .target(name, path, _) = node,
-            let target = target(path:  path, name: name),
+            let target = target(path: path, name: name),
             target.target.product == .unitTests,
             let appHostTarget = unitTestHost(path: path, name: name)
-        {
-            appHostDependency = GraphDependency.target(
-                name: appHostTarget.target.name,
-                path: appHostTarget.path,
-                status: .required
-            )
+        else {
+            return nil
         }
 
-        let directDependencies = graph.dependencies[node] ?? []
-        if directDependencies.isEmpty {
-            linkableDependenciesSearchCache[node] = []
-            return []
-        }
+        return GraphDependency.target(
+            name: appHostTarget.target.name,
+            path: appHostTarget.path,
+            status: .required
+        )
+    }
 
-        var result: Set<GraphDependency> = []
-
-        // collect every transitive dependency
-        for dependency in directDependencies {
-            // skip macroses, and other dependencies that should not be linked
-            guard isDependencyLinkable(dependency: dependency) || dependency == appHostDependency else { continue }
-
-            result.insert(dependency)
-
-            result.formUnion(linkableDependenciesSearch(from: dependency))
-        }
-
-        // Dependencies, that need to be removed from linking tree
-        // For example, if App uses static framework Framework1 transitively through
-        // dynamic framework, Framework1 should not be linked to App, because in such case
-        // Framework1 will be linked two times to App and to dynamic framework
+    private func finalizeLinkableDependencies(
+        _ collectedDependencies: Set<GraphDependency>,
+        directDependencies: Set<GraphDependency>
+    ) -> Set<GraphDependency> {
+        var result = collectedDependencies
         var dependenciesToRemove = Set<GraphDependency>()
         var dependenciesToAdd = Set<GraphDependency>()
-        for dependency in result {
-            // process only dynamic dependencies
-            guard canDependencyLinkStaticProducts(dependency: dependency) else { continue }
 
-            var searchResult = linkableDependenciesSearch(from: dependency)
-            searchResult = searchResult.filter {
-                return !(isDependencyDynamic(dependency: $0) && directDependencies.contains($0))
+        // Static dependencies linked through dynamic products should not also be linked directly.
+        for dependency in result {
+            guard canDependencyLinkStaticProducts(dependency: dependency) else {
+                continue
             }
-            // if dynamic dependency contains static dependency, which is gonna be removed, 
-            // we should link such dependency, because otherwise there will be linking error
-            // telling us that linker did not find symbol from removed static dependency
+
+            var searchResult = linkableDependenciesSearchCache[dependency] ?? []
+            searchResult = searchResult.filter {
+                !(isDependencyDynamic(dependency: $0) && directDependencies.contains($0))
+            }
+
+            // Keep the owner of a removed static dependency so its symbols remain available.
             if searchResult.contains(where: { isDependencyStatic(dependency: $0) }) {
                 dependenciesToAdd.insert(dependency)
             }
-
             dependenciesToRemove.formUnion(searchResult)
         }
 
         result.subtract(dependenciesToRemove)
 
-        // sdks and dynamic frameworks should be linked if they are used through static frameworks
-        // so we walk through each static dependency and search for dynamic dependencies and sdks
-        // (sdks are considered dynamic dependencies)
-        for dependency in result {
-            guard isDependencyStatic(dependency: dependency) else { continue }
+        // SDKs and dynamic frameworks remain linkable through static dependencies.
+        for dependency in Array(result) {
+            guard isDependencyStatic(dependency: dependency) else {
+                continue
+            }
 
-            let searchResult = linkableDependenciesSearch(from: dependency)
-
+            let searchResult = linkableDependenciesSearchCache[dependency] ?? []
             result.formUnion(searchResult.filter { isDependencyDynamic(dependency: $0) })
         }
 
         result.formUnion(dependenciesToAdd)
 
-        // direct dependencies and sdks also should be added to linking, in case if we
-        // removed them in code above
+        // Restore direct dynamic dependencies if transitive pruning removed them.
         result.formUnion(directDependencies.filter { isDependencyDynamic(dependency: $0) })
-
-        linkableDependenciesSearchCache[node] = result
-
         return result
     }
 
@@ -737,14 +852,15 @@ public class GraphTraverser: GraphTraversing {
 
     public func directSwiftMacroTargets(path: AbsolutePath, name: String) -> Set<GraphTargetReference> {
         let dependencies = directTargetDependencies(path: path, name: name)
-            .filter { [.staticFramework, .framework, .dynamicLibrary, .staticLibrary].contains($0.target.product) }
-            .filter { self.directSwiftMacroExecutables(path: $0.graphTarget.path, name: $0.graphTarget.target.name).count != 0 }
+            .filter { isLinkableTargetWithDirectSwiftMacro($0.graphTarget) }
         return Set(dependencies)
     }
 
     private var allMacroTargetsCache: [GraphTarget: Set<GraphTarget>] = [:]
     private var allMacroTargetsLock = NSRecursiveLock()
 
+    /// Returns linkable targets that directly depend on Swift macro targets, including those reached transitively.
+    /// The macro targets themselves are not included.
     public func allSwiftMacroTargets(path: AbsolutePath, name: String) -> Set<GraphTarget> {
         allMacroTargetsLock.lock()
         defer { allMacroTargetsLock.unlock() }
@@ -755,20 +871,66 @@ public class GraphTraverser: GraphTraversing {
             return cached
         }
 
-        var result = Set<GraphTarget>()
+        var activeTargets = Set([target])
+        var stack = [swiftMacroTargetsTraversalFrame(for: target)]
 
-        for dep in directTargetDependencies(path: path, name: name).map(\.graphTarget) {
-            if [.staticFramework, .framework, .dynamicLibrary, .staticLibrary].contains(dep.target.product),
-                directSwiftMacroExecutables(path: dep.path, name: dep.target.name).count != 0
-            {
-                result.insert(dep)
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let dependency = frame.dependencies[frame.nextDependencyIndex]
+
+                if isLinkableTargetWithDirectSwiftMacro(dependency) {
+                    stack[frameIndex].result.insert(dependency)
+                }
+
+                if let cached = allMacroTargetsCache[dependency] {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].result.formUnion(cached)
+                    continue
+                }
+
+                guard !activeTargets.contains(dependency) else {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                activeTargets.insert(dependency)
+                stack.append(swiftMacroTargetsTraversalFrame(for: dependency))
+            } else {
+                let completedFrame = stack.removeLast()
+                allMacroTargetsCache[completedFrame.target] = completedFrame.result
+                activeTargets.remove(completedFrame.target)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
+                }
             }
-
-            result.formUnion(allSwiftMacroTargets(path: dep.path, name: dep.target.name))
         }
 
-        allMacroTargetsCache[target] = result
-        return result
+        return allMacroTargetsCache[target] ?? []
+    }
+
+    private func swiftMacroTargetsTraversalFrame(for target: GraphTarget) -> SwiftMacroTargetsTraversalFrame {
+        SwiftMacroTargetsTraversalFrame(
+            target: target,
+            dependencies: Array(
+                directTargetDependencies(path: target.path, name: target.target.name).map(\.graphTarget)
+            ),
+            nextDependencyIndex: 0,
+            result: []
+        )
+    }
+
+    private func isLinkableTargetWithDirectSwiftMacro(_ target: GraphTarget) -> Bool {
+        switch target.target.product {
+        case .staticFramework, .framework, .dynamicLibrary, .staticLibrary:
+            return !directSwiftMacroExecutables(path: target.path, name: target.target.name).isEmpty
+        default:
+            return false
+        }
     }
 
     public func librariesPublicHeadersFolders(path: AbsolutePath, name: String) -> Set<AbsolutePath> {
@@ -1153,46 +1315,84 @@ public class GraphTraverser: GraphTraversing {
 
     private func calculateCombinedConditionMap() {
         var result: [GraphDependency: [GraphDependency: PlatformCondition.CombinationResult]] = [:]
+        var completedDependencies = Set<GraphDependency>()
 
-        func dfs(_ node: GraphDependency) {
-            guard result[node] == nil else { return }
+        // Resolve nodes in postorder because a parent's condition map depends on completed child maps.
+        for node in graph.dependencies.keys {
+            guard !completedDependencies.contains(node) else {
+                continue
+            }
 
-            for dep in graph.dependencies[node] ?? [] {
-                dfs(dep)
+            var activeDependencies = Set([node])
+            var stack = [
+                ConditionMapTraversalFrame(
+                    node: node,
+                    dependencies: Array(graph.dependencies[node] ?? []),
+                    nextDependencyIndex: 0,
+                    result: [:]
+                ),
+            ]
 
-                let currentCondition = graph.dependencyConditions[(node, dep)]
+            while !stack.isEmpty {
+                let frameIndex = stack.count - 1
+                let frame = stack[frameIndex]
 
-                // Capture the filters that could be applied to intermediate dependencies
-                // A --> (.ios) B --> C : C should have the .ios filter applied due to B
-                for (transitiveDep, transitiveCondition) in result[dep] ?? [:] {
-                    let combinedCondition: PlatformCondition.CombinationResult
-                    switch transitiveCondition {
-                    case .incompatible:
-                        combinedCondition = .incompatible
-                    case let .condition(.some(condition)):
-                        combinedCondition = condition.intersection(currentCondition)
-                    case .condition:
-                        combinedCondition = .condition(currentCondition)
+                if frame.nextDependencyIndex < frame.dependencies.count {
+                    let dependency = frame.dependencies[frame.nextDependencyIndex]
+
+                    if completedDependencies.contains(dependency) {
+                        let currentCondition = graph.dependencyConditions[(frame.node, dependency)]
+
+                        // Capture filters applied by intermediate dependencies.
+                        for (transitiveDependency, transitiveCondition) in result[dependency] ?? [:] {
+                            let combinedCondition: PlatformCondition.CombinationResult
+                            switch transitiveCondition {
+                            case .incompatible:
+                                combinedCondition = .incompatible
+                            case let .condition(.some(condition)):
+                                combinedCondition = condition.intersection(currentCondition)
+                            case .condition:
+                                combinedCondition = .condition(currentCondition)
+                            }
+
+                            let previousResult =
+                                stack[frameIndex].result[transitiveDependency] ?? .incompatible
+
+                            // Combine filters from every path that reaches the same dependency.
+                            stack[frameIndex].result[transitiveDependency] =
+                                previousResult.combineWith(combinedCondition)
+                        }
+
+                        stack[frameIndex].nextDependencyIndex += 1
+                        continue
                     }
 
-                    // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
-                    //  A --> (.ios) B --> C
-                    //  A --> (.macos) D --> C
-                    // C should have `[.ios, .macos]` set for filters to satisfy both paths
-                    let previousResult = result[node, default: [:]][transitiveDep] ?? .incompatible
-                    let newResult = previousResult.combineWith(combinedCondition)
+                    if activeDependencies.contains(dependency) {
+                        stack[frameIndex].nextDependencyIndex += 1
+                        continue
+                    }
 
-                    result[node, default: [:]][transitiveDep] = newResult
+                    activeDependencies.insert(dependency)
+                    stack.append(
+                        ConditionMapTraversalFrame(
+                            node: dependency,
+                            dependencies: Array(graph.dependencies[dependency] ?? []),
+                            nextDependencyIndex: 0,
+                            result: [:]
+                        )
+                    )
+                } else {
+                    for dependency in frame.dependencies {
+                        stack[frameIndex].result[dependency] =
+                            .condition(graph.dependencyConditions[(frame.node, dependency)])
+                    }
+
+                    let completedFrame = stack.removeLast()
+                    result[completedFrame.node] = completedFrame.result
+                    completedDependencies.insert(completedFrame.node)
+                    activeDependencies.remove(completedFrame.node)
                 }
             }
-
-            for dep in graph.dependencies[node] ?? [] {
-                result[node, default: [:]][dep] = .condition(graph.dependencyConditions[(node, dep)])
-            }
-        }
-
-        for node in graph.dependencies.keys {
-            dfs(node)
         }
 
         conditionMap = result
@@ -1202,32 +1402,36 @@ public class GraphTraverser: GraphTraversing {
     public func externalTargetSupportedPlatforms() -> [GraphTarget: Set<Platform>] {
         let targetsWithExternalDependencies = targetsWithExternalDependencies()
         var platforms: [GraphTarget: Set<Platform>] = [:]
+        var stack = targetsWithExternalDependencies.map {
+            (target: $0, parentPlatforms: $0.target.supportedPlatforms)
+        }
 
-        func traverse(target: GraphTarget, parentPlatforms: Set<Platform>) {
-            let dependencies = directTargetDependencies(path: target.path, name: target.target.name)
+        while let item = stack.popLast() {
+            let dependencies = directTargetDependencies(
+                path: item.target.path,
+                name: item.target.target.name
+            )
 
             for dependencyTargetReference in dependencies {
                 var platformsToInsert: Set<Platform>?
                 let dependencyTarget = dependencyTargetReference.graphTarget
                 let inheritedPlatforms =
                     dependencyTarget.target.product == .macro
-                        ? Set<Platform>([.macOS]) : parentPlatforms
-                
+                        ? Set<Platform>([.macOS]) : item.parentPlatforms
+
                 if let dependencyCondition = dependencyTargetReference.condition,
-                    let platformIntersection = PlatformCondition.when(target.target.dependencyPlatformFilters)?
-                        .intersection(dependencyCondition)
+                   let platformIntersection = PlatformCondition.when(item.target.target.dependencyPlatformFilters)?
+                       .intersection(dependencyCondition)
                 {
                     switch platformIntersection {
                     case .incompatible:
                         break
                     case let .condition(condition):
                         if let condition {
-                            let dependencyPlatforms = Set(
-                                condition.platformFilters.map(\.platform)
-                                    .filter { $0 != nil }
-                                    .map { $0! }
+                            platformsToInsert = Set(
+                                condition.platformFilters
+                                    .compactMap(\.platform)
                             ).intersection(inheritedPlatforms)
-                            platformsToInsert = dependencyPlatforms
                         }
                     }
                 } else {
@@ -1236,20 +1440,27 @@ public class GraphTraverser: GraphTraversing {
                     )
                 }
 
-                if let platformsToInsert {
-                    var existingPlatforms = platforms[dependencyTarget, default: Set()]
-                    let continueTraversing = !platformsToInsert.isSubset(of: existingPlatforms)
-                    existingPlatforms.formUnion(platformsToInsert)
-                    platforms[dependencyTarget] = existingPlatforms
+                guard let platformsToInsert else {
+                    continue
+                }
 
-                    if continueTraversing {
-                        traverse(target: dependencyTarget, parentPlatforms: platforms[dependencyTarget, default: Set()])
-                    }
+                var existingPlatforms = platforms[dependencyTarget, default: Set()]
+                let continueTraversing = !platformsToInsert.isSubset(of: existingPlatforms)
+                existingPlatforms.formUnion(platformsToInsert)
+                platforms[dependencyTarget] = existingPlatforms
+
+                if continueTraversing {
+                    // Platform sets only grow, so revisit a target only when new platforms are discovered.
+                    stack.append(
+                        (
+                            target: dependencyTarget,
+                            parentPlatforms: existingPlatforms
+                        )
+                    )
                 }
             }
         }
 
-        targetsWithExternalDependencies.forEach { traverse(target: $0, parentPlatforms: $0.target.supportedPlatforms) }
         return platforms
     }
 

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -676,6 +676,8 @@ public class GraphTraverser: GraphTraversing {
             ),
         ]
 
+        // Collect every transitive linkable dependency in postorder so child cache entries
+        // are ready before their parents are finalized.
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
@@ -758,7 +760,10 @@ public class GraphTraverser: GraphTraversing {
         var dependenciesToRemove = Set<GraphDependency>()
         var dependenciesToAdd = Set<GraphDependency>()
 
-        // Static dependencies linked through dynamic products should not also be linked directly.
+        // Dependencies, that need to be removed from linking tree
+        // For example, if App uses static framework Framework1 transitively through
+        // dynamic framework, Framework1 should not be linked to App, because in such case
+        // Framework1 will be linked two times to App and to dynamic framework
         for dependency in result {
             guard canDependencyLinkStaticProducts(dependency: dependency) else {
                 continue
@@ -769,7 +774,9 @@ public class GraphTraverser: GraphTraversing {
                 !(isDependencyDynamic(dependency: $0) && directDependencies.contains($0))
             }
 
-            // Keep the owner of a removed static dependency so its symbols remain available.
+            // if dynamic dependency contains static dependency, which is gonna be removed,
+            // we should link such dependency, because otherwise there will be linking error
+            // telling us that linker did not find symbol from removed static dependency
             if searchResult.contains(where: { isDependencyStatic(dependency: $0) }) {
                 dependenciesToAdd.insert(dependency)
             }
@@ -778,7 +785,9 @@ public class GraphTraverser: GraphTraversing {
 
         result.subtract(dependenciesToRemove)
 
-        // SDKs and dynamic frameworks remain linkable through static dependencies.
+        // sdks and dynamic frameworks should be linked if they are used through static frameworks
+        // so we walk through each static dependency and search for dynamic dependencies and sdks
+        // (sdks are considered dynamic dependencies)
         for dependency in Array(result) {
             guard isDependencyStatic(dependency: dependency) else {
                 continue
@@ -790,7 +799,8 @@ public class GraphTraverser: GraphTraversing {
 
         result.formUnion(dependenciesToAdd)
 
-        // Restore direct dynamic dependencies if transitive pruning removed them.
+        // direct dependencies and sdks also should be added to linking, in case if we
+        // removed them in code above
         result.formUnion(directDependencies.filter { isDependencyDynamic(dependency: $0) })
         return result
     }
@@ -1343,7 +1353,8 @@ public class GraphTraverser: GraphTraversing {
                     if completedDependencies.contains(dependency) {
                         let currentCondition = graph.dependencyConditions[(frame.node, dependency)]
 
-                        // Capture filters applied by intermediate dependencies.
+                        // Capture the filters that could be applied to intermediate dependencies
+                        // A --> (.ios) B --> C : C should have the .ios filter applied due to B
                         for (transitiveDependency, transitiveCondition) in result[dependency] ?? [:] {
                             let combinedCondition: PlatformCondition.CombinationResult
                             switch transitiveCondition {
@@ -1358,7 +1369,10 @@ public class GraphTraverser: GraphTraversing {
                             let previousResult =
                                 stack[frameIndex].result[transitiveDependency] ?? .incompatible
 
-                            // Combine filters from every path that reaches the same dependency.
+                            // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
+                            //  A --> (.ios) B --> C
+                            //  A --> (.macos) D --> C
+                            // C should have `[.ios, .macos]` set for filters to satisfy both paths
                             stack[frameIndex].result[transitiveDependency] =
                                 previousResult.combineWith(combinedCondition)
                         }

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -515,34 +515,26 @@ public class GraphTraverser: GraphTraversing {
     }
 
     public func searchablePathDependencies(path: AbsolutePath, name: String) throws -> Set<GraphDependencyReference> {
-        var result = Set<GraphDependencyReference>()
-        var currentPath = path
-        var currentName = name
-        var visitedTargets = Set<GraphDependency>()
+        let deps = try linkableDependencies(
+            path: path,
+            name: name,
+            shouldExcludeNonLinkableDependencies: false
+        )
 
-        while visitedTargets.insert(.target(name: currentName, path: currentPath)).inserted {
-            result.formUnion(
-                try linkableDependencies(
-                    path: currentPath,
-                    name: currentName,
-                    shouldExcludeNonLinkableDependencies: false
+        if let target = target(path: path, name: name),
+           target.target.product == .unitTests || target.target.product == .uiTests,
+           let appHostTarget = unitTestHost(path: path, name: name)
+        {
+            // Unit and UI tests can use the same dependencies as their host app without linking them.
+            return deps.union(
+                try searchablePathDependencies(
+                    path: appHostTarget.path,
+                    name: appHostTarget.target.name
                 )
             )
-
-            guard
-                let target = target(path: currentPath, name: currentName),
-                target.target.product == .unitTests || target.target.product == .uiTests,
-                let appHostTarget = unitTestHost(path: currentPath, name: currentName)
-            else {
-                break
-            }
-
-            // Unit and UI tests can use the same dependencies as their host app without linking them.
-            currentPath = appHostTarget.path
-            currentName = appHostTarget.target.name
         }
 
-        return result
+        return deps
     }
 
     public func linkableDependencies(path: AbsolutePath, name: String) throws -> Set<GraphDependencyReference> {
@@ -704,11 +696,11 @@ public class GraphTraverser: GraphTraversing {
                     collectedDependencies.formUnion(linkableDependenciesSearchCache[dependency] ?? [])
                 }
 
-                let result = finalizeLinkableDependencies(
-                    collectedDependencies,
+                finalizeLinkableDependencies(
+                    &collectedDependencies,
                     directDependencies: frame.dependencies
                 )
-                linkableDependenciesSearchCache[frame.node] = result
+                linkableDependenciesSearchCache[frame.node] = collectedDependencies
                 activeDependencies.remove(frame.node)
                 stack.removeLast()
             }
@@ -735,10 +727,9 @@ public class GraphTraverser: GraphTraversing {
     }
 
     private func finalizeLinkableDependencies(
-        _ collectedDependencies: Set<GraphDependency>,
+        _ collectedDependencies: inout Set<GraphDependency>,
         directDependencies: Set<GraphDependency>
-    ) -> Set<GraphDependency> {
-        var result = collectedDependencies
+    ) {
         var dependenciesToRemove = Set<GraphDependency>()
         var dependenciesToAdd = Set<GraphDependency>()
 
@@ -746,7 +737,7 @@ public class GraphTraverser: GraphTraversing {
         // For example, if App uses static framework Framework1 transitively through
         // dynamic framework, Framework1 should not be linked to App, because in such case
         // Framework1 will be linked two times to App and to dynamic framework
-        for dependency in result {
+        for dependency in collectedDependencies {
             guard canDependencyLinkStaticProducts(dependency: dependency) else {
                 continue
             }
@@ -765,26 +756,25 @@ public class GraphTraverser: GraphTraversing {
             dependenciesToRemove.formUnion(searchResult)
         }
 
-        result.subtract(dependenciesToRemove)
+        collectedDependencies.subtract(dependenciesToRemove)
 
         // sdks and dynamic frameworks should be linked if they are used through static frameworks
         // so we walk through each static dependency and search for dynamic dependencies and sdks
         // (sdks are considered dynamic dependencies)
-        for dependency in Array(result) {
+        for dependency in collectedDependencies {
             guard isDependencyStatic(dependency: dependency) else {
                 continue
             }
 
             let searchResult = linkableDependenciesSearchCache[dependency] ?? []
-            result.formUnion(searchResult.filter { isDependencyDynamic(dependency: $0) })
+            collectedDependencies.formUnion(searchResult.filter { isDependencyDynamic(dependency: $0) })
         }
 
-        result.formUnion(dependenciesToAdd)
+        collectedDependencies.formUnion(dependenciesToAdd)
 
         // direct dependencies and sdks also should be added to linking, in case if we
         // removed them in code above
-        result.formUnion(directDependencies.filter { isDependencyDynamic(dependency: $0) })
-        return result
+        collectedDependencies.formUnion(directDependencies.filter { isDependencyDynamic(dependency: $0) })
     }
 
     public func staticXCFrameworkDependencies(path: AbsolutePath, name: String) -> Set<GraphDependencyReference> {
@@ -1321,88 +1311,77 @@ public class GraphTraverser: GraphTraversing {
         }
 
         var result: [GraphDependency: [GraphDependency: PlatformCondition.CombinationResult]] = [:]
-        var completedDependencies = Set<GraphDependency>()
 
         // Resolve nodes in postorder because a parent's condition map depends on completed child maps.
-        for node in graph.dependencies.keys {
-            guard !completedDependencies.contains(node) else {
-                continue
-            }
+        var stack = graph.dependencies.map {
+            ConditionMapTraversalFrame(
+                node: $0.key,
+                dependencies: $0.value,
+                preOrderVisit: true
+            )
+        }
 
-            var activeDependencies = Set<GraphDependency>()
-            var stack = [
-                ConditionMapTraversalFrame(
-                    node: node,
-                    dependencies: graph.dependencies[node] ?? [],
-                    preOrderVisit: true
-                ),
-            ]
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
 
-            while !stack.isEmpty {
-                let frameIndex = stack.count - 1
-                let frame = stack[frameIndex]
+            if frame.preOrderVisit {
+                guard result[frame.node] == nil else {
+                    stack.removeLast()
+                    continue
+                }
 
-                if frame.preOrderVisit {
-                    guard
-                        !completedDependencies.contains(frame.node),
-                        activeDependencies.insert(frame.node).inserted
-                    else {
-                        stack.removeLast()
-                        continue
-                    }
-
-                    stack[frameIndex].preOrderVisit = false
-                    for dependency in frame.dependencies {
-                        stack.append(
-                            ConditionMapTraversalFrame(
-                                node: dependency,
-                                dependencies: graph.dependencies[dependency] ?? [],
-                                preOrderVisit: true
-                            )
+                // Store an empty placeholder before visiting dependencies to avoid processing
+                // the same node again. The final result overwrites it in postorder.
+                result[frame.node] = [:]
+                stack[frameIndex].preOrderVisit = false
+                for dependency in frame.dependencies {
+                    stack.append(
+                        ConditionMapTraversalFrame(
+                            node: dependency,
+                            dependencies: graph.dependencies[dependency] ?? [],
+                            preOrderVisit: true
                         )
-                    }
-                } else {
-                    var nodeResult: [GraphDependency: PlatformCondition.CombinationResult] = [:]
+                    )
+                }
+            } else {
+                var nodeResult: [GraphDependency: PlatformCondition.CombinationResult] = [:]
 
-                    for dependency in frame.dependencies {
-                        let currentCondition = graph.dependencyConditions[(frame.node, dependency)]
+                for dependency in frame.dependencies {
+                    let currentCondition = graph.dependencyConditions[(frame.node, dependency)]
 
-                        // Capture the filters that could be applied to intermediate dependencies
-                        // A --> (.ios) B --> C : C should have the .ios filter applied due to B
-                        for (transitiveDependency, transitiveCondition) in result[dependency] ?? [:] {
-                            let combinedCondition: PlatformCondition.CombinationResult
-                            switch transitiveCondition {
-                            case .incompatible:
-                                combinedCondition = .incompatible
-                            case let .condition(.some(condition)):
-                                combinedCondition = condition.intersection(currentCondition)
-                            case .condition:
-                                combinedCondition = .condition(currentCondition)
-                            }
+                    // Capture the filters that could be applied to intermediate dependencies
+                    // A --> (.ios) B --> C : C should have the .ios filter applied due to B
+                    for (transitiveDependency, transitiveCondition) in result[dependency] ?? [:] {
+                        let combinedCondition: PlatformCondition.CombinationResult
+                        switch transitiveCondition {
+                        case .incompatible:
+                            combinedCondition = .incompatible
 
-                            let previousResult =
-                                nodeResult[transitiveDependency] ?? .incompatible
+                        case let .condition(.some(condition)):
+                            combinedCondition = condition.intersection(currentCondition)
 
-                            // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
-                            //  A --> (.ios) B --> C
-                            //  A --> (.macos) D --> C
-                            // C should have `[.ios, .macos]` set for filters to satisfy both paths
-                            nodeResult[transitiveDependency] =
-                                previousResult.combineWith(combinedCondition)
+                        case .condition:
+                            combinedCondition = .condition(currentCondition)
                         }
 
+                        let previousResult = nodeResult[transitiveDependency] ?? .incompatible
+
+                        // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
+                        //  A --> (.ios) B --> C
+                        //  A --> (.macos) D --> C
+                        // C should have `[.ios, .macos]` set for filters to satisfy both paths
+                        nodeResult[transitiveDependency] = previousResult.combineWith(combinedCondition)
                     }
 
-                    for dependency in frame.dependencies {
-                        nodeResult[dependency] =
-                            .condition(graph.dependencyConditions[(frame.node, dependency)])
-                    }
-
-                    result[frame.node] = nodeResult
-                    completedDependencies.insert(frame.node)
-                    activeDependencies.remove(frame.node)
-                    stack.removeLast()
                 }
+
+                for dependency in frame.dependencies {
+                    nodeResult[dependency] = .condition(graph.dependencyConditions[(frame.node, dependency)])
+                }
+
+                result[frame.node] = nodeResult
+                stack.removeLast()
             }
         }
 

--- a/Sources/GekoCore/Graph/GraphTraverser.swift
+++ b/Sources/GekoCore/Graph/GraphTraverser.swift
@@ -7,23 +7,20 @@ import ProjectDescription
 public class GraphTraverser: GraphTraversing {
     private struct DependencySetTraversalFrame {
         let node: GraphDependency
-        let dependencies: [GraphDependency]
-        var nextDependencyIndex: Int
-        var result: Set<GraphDependency>
+        let dependencies: Set<GraphDependency>
+        var preOrderVisit: Bool
     }
 
     private struct ConditionMapTraversalFrame {
         let node: GraphDependency
-        let dependencies: [GraphDependency]
-        var nextDependencyIndex: Int
-        var result: [GraphDependency: PlatformCondition.CombinationResult]
+        let dependencies: Set<GraphDependency>
+        var preOrderVisit: Bool
     }
 
     private struct SwiftMacroTargetsTraversalFrame {
         let target: GraphTarget
-        let dependencies: [GraphTarget]
-        var nextDependencyIndex: Int
-        var result: Set<GraphTarget>
+        let dependencies: Set<GraphTarget>
+        var preOrderVisit: Bool
     }
 
     public var name: String { graph.name }
@@ -159,14 +156,12 @@ public class GraphTraverser: GraphTraversing {
             }
         }
 
-        let rootDependencies = Array(graph.dependencies[targetGraphDependency] ?? [])
-        var activeDependencies = Set([targetGraphDependency])
+        var activeDependencies = Set<GraphDependency>()
         var stack = [
             DependencySetTraversalFrame(
                 node: targetGraphDependency,
-                dependencies: rootDependencies,
-                nextDependencyIndex: 0,
-                result: Set(rootDependencies)
+                dependencies: graph.dependencies[targetGraphDependency] ?? [],
+                preOrderVisit: true
             ),
         ]
 
@@ -174,39 +169,35 @@ public class GraphTraverser: GraphTraversing {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.dependencies.count {
-                let dependency = frame.dependencies[frame.nextDependencyIndex]
-
-                if let cachedDependencies = allTargetDependenciesCache[dependency] {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].result.formUnion(cachedDependencies)
+            if frame.preOrderVisit {
+                guard
+                    allTargetDependenciesCache[frame.node] == nil,
+                    activeDependencies.insert(frame.node).inserted
+                else {
+                    stack.removeLast()
                     continue
                 }
 
-                if activeDependencies.contains(dependency) {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
+                stack[frameIndex].preOrderVisit = false
 
-                let dependencies = Array(graph.dependencies[dependency] ?? [])
-                activeDependencies.insert(dependency)
-                stack.append(
-                    DependencySetTraversalFrame(
-                        node: dependency,
-                        dependencies: dependencies,
-                        nextDependencyIndex: 0,
-                        result: Set(dependencies)
+                for dependency in frame.dependencies {
+                    stack.append(
+                        DependencySetTraversalFrame(
+                            node: dependency,
+                            dependencies: graph.dependencies[dependency] ?? [],
+                            preOrderVisit: true
+                        )
                     )
-                )
-            } else {
-                let completedFrame = stack.removeLast()
-                allTargetDependenciesCache[completedFrame.node] = completedFrame.result
-                activeDependencies.remove(completedFrame.node)
-
-                if let parentFrameIndex = stack.indices.last {
-                    stack[parentFrameIndex].nextDependencyIndex += 1
-                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
                 }
+            } else {
+                var result = frame.dependencies
+                for dependency in frame.dependencies {
+                    result.formUnion(allTargetDependenciesCache[dependency] ?? [])
+                }
+
+                allTargetDependenciesCache[frame.node] = result
+                activeDependencies.remove(frame.node)
+                stack.removeLast()
             }
         }
 
@@ -665,14 +656,12 @@ public class GraphTraverser: GraphTraversing {
             return cached
         }
 
-        let directDependencies = Array(graph.dependencies[node] ?? [])
-        var activeDependencies = Set([node])
+        var activeDependencies = Set<GraphDependency>()
         var stack = [
             DependencySetTraversalFrame(
                 node: node,
-                dependencies: directDependencies,
-                nextDependencyIndex: 0,
-                result: []
+                dependencies: graph.dependencies[node] ?? [],
+                preOrderVisit: true
             ),
         ]
 
@@ -682,53 +671,52 @@ public class GraphTraverser: GraphTraversing {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.dependencies.count {
-                let dependency = frame.dependencies[frame.nextDependencyIndex]
+            if frame.preOrderVisit {
+                guard
+                    linkableDependenciesSearchCache[frame.node] == nil,
+                    activeDependencies.insert(frame.node).inserted
+                else {
+                    stack.removeLast()
+                    continue
+                }
+
+                stack[frameIndex].preOrderVisit = false
                 let appHostDependency = appHostDependency(for: frame.node)
 
-                // Macro executables and other non-linkable dependencies are not part of the linking tree.
-                guard isDependencyLinkable(dependency: dependency) || dependency == appHostDependency else {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
+                for dependency in frame.dependencies {
+                    // Macro executables and other non-linkable dependencies are not part of the linking tree.
+                    guard isDependencyLinkable(dependency: dependency) || dependency == appHostDependency else {
+                        continue
+                    }
 
-                stack[frameIndex].result.insert(dependency)
-
-                if let cachedDependencies = linkableDependenciesSearchCache[dependency] {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].result.formUnion(cachedDependencies)
-                    continue
-                }
-
-                if activeDependencies.contains(dependency) {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
-
-                activeDependencies.insert(dependency)
-                stack.append(
-                    DependencySetTraversalFrame(
-                        node: dependency,
-                        dependencies: Array(graph.dependencies[dependency] ?? []),
-                        nextDependencyIndex: 0,
-                        result: []
+                    stack.append(
+                        DependencySetTraversalFrame(
+                            node: dependency,
+                            dependencies: graph.dependencies[dependency] ?? [],
+                            preOrderVisit: true
+                        )
                     )
-                )
-            } else {
-                let completedFrame = stack.removeLast()
-                let result = finalizeLinkableDependencies(
-                    completedFrame.result,
-                    directDependencies: Set(completedFrame.dependencies)
-                )
-                linkableDependenciesSearchCache[completedFrame.node] = result
-                activeDependencies.remove(completedFrame.node)
-
-                if let parentFrameIndex = stack.indices.last {
-                    stack[parentFrameIndex].nextDependencyIndex += 1
-                    stack[parentFrameIndex].result.formUnion(result)
-                } else {
-                    return result
                 }
+            } else {
+                var collectedDependencies = Set<GraphDependency>()
+                let appHostDependency = appHostDependency(for: frame.node)
+
+                for dependency in frame.dependencies {
+                    guard isDependencyLinkable(dependency: dependency) || dependency == appHostDependency else {
+                        continue
+                    }
+
+                    collectedDependencies.insert(dependency)
+                    collectedDependencies.formUnion(linkableDependenciesSearchCache[dependency] ?? [])
+                }
+
+                let result = finalizeLinkableDependencies(
+                    collectedDependencies,
+                    directDependencies: frame.dependencies
+                )
+                linkableDependenciesSearchCache[frame.node] = result
+                activeDependencies.remove(frame.node)
+                stack.removeLast()
             }
         }
 
@@ -881,42 +869,39 @@ public class GraphTraverser: GraphTraversing {
             return cached
         }
 
-        var activeTargets = Set([target])
+        var activeTargets = Set<GraphTarget>()
         var stack = [swiftMacroTargetsTraversalFrame(for: target)]
 
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.dependencies.count {
-                let dependency = frame.dependencies[frame.nextDependencyIndex]
-
-                if isLinkableTargetWithDirectSwiftMacro(dependency) {
-                    stack[frameIndex].result.insert(dependency)
-                }
-
-                if let cached = allMacroTargetsCache[dependency] {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].result.formUnion(cached)
+            if frame.preOrderVisit {
+                guard
+                    allMacroTargetsCache[frame.target] == nil,
+                    activeTargets.insert(frame.target).inserted
+                else {
+                    stack.removeLast()
                     continue
                 }
 
-                guard !activeTargets.contains(dependency) else {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
+                stack[frameIndex].preOrderVisit = false
+                for dependency in frame.dependencies {
+                    stack.append(swiftMacroTargetsTraversalFrame(for: dependency))
                 }
-
-                activeTargets.insert(dependency)
-                stack.append(swiftMacroTargetsTraversalFrame(for: dependency))
             } else {
-                let completedFrame = stack.removeLast()
-                allMacroTargetsCache[completedFrame.target] = completedFrame.result
-                activeTargets.remove(completedFrame.target)
+                var result = Set<GraphTarget>()
+                for dependency in frame.dependencies {
+                    if isLinkableTargetWithDirectSwiftMacro(dependency) {
+                        result.insert(dependency)
+                    }
 
-                if let parentFrameIndex = stack.indices.last {
-                    stack[parentFrameIndex].nextDependencyIndex += 1
-                    stack[parentFrameIndex].result.formUnion(completedFrame.result)
+                    result.formUnion(allMacroTargetsCache[dependency] ?? [])
                 }
+
+                allMacroTargetsCache[frame.target] = result
+                activeTargets.remove(frame.target)
+                stack.removeLast()
             }
         }
 
@@ -926,11 +911,10 @@ public class GraphTraverser: GraphTraversing {
     private func swiftMacroTargetsTraversalFrame(for target: GraphTarget) -> SwiftMacroTargetsTraversalFrame {
         SwiftMacroTargetsTraversalFrame(
             target: target,
-            dependencies: Array(
+            dependencies: Set(
                 directTargetDependencies(path: target.path, name: target.target.name).map(\.graphTarget)
             ),
-            nextDependencyIndex: 0,
-            result: []
+            preOrderVisit: true
         )
     }
 
@@ -1333,13 +1317,12 @@ public class GraphTraverser: GraphTraversing {
                 continue
             }
 
-            var activeDependencies = Set([node])
+            var activeDependencies = Set<GraphDependency>()
             var stack = [
                 ConditionMapTraversalFrame(
                     node: node,
-                    dependencies: Array(graph.dependencies[node] ?? []),
-                    nextDependencyIndex: 0,
-                    result: [:]
+                    dependencies: graph.dependencies[node] ?? [],
+                    preOrderVisit: true
                 ),
             ]
 
@@ -1347,10 +1330,29 @@ public class GraphTraverser: GraphTraversing {
                 let frameIndex = stack.count - 1
                 let frame = stack[frameIndex]
 
-                if frame.nextDependencyIndex < frame.dependencies.count {
-                    let dependency = frame.dependencies[frame.nextDependencyIndex]
+                if frame.preOrderVisit {
+                    guard
+                        !completedDependencies.contains(frame.node),
+                        activeDependencies.insert(frame.node).inserted
+                    else {
+                        stack.removeLast()
+                        continue
+                    }
 
-                    if completedDependencies.contains(dependency) {
+                    stack[frameIndex].preOrderVisit = false
+                    for dependency in frame.dependencies {
+                        stack.append(
+                            ConditionMapTraversalFrame(
+                                node: dependency,
+                                dependencies: graph.dependencies[dependency] ?? [],
+                                preOrderVisit: true
+                            )
+                        )
+                    }
+                } else {
+                    var nodeResult: [GraphDependency: PlatformCondition.CombinationResult] = [:]
+
+                    for dependency in frame.dependencies {
                         let currentCondition = graph.dependencyConditions[(frame.node, dependency)]
 
                         // Capture the filters that could be applied to intermediate dependencies
@@ -1367,44 +1369,27 @@ public class GraphTraverser: GraphTraversing {
                             }
 
                             let previousResult =
-                                stack[frameIndex].result[transitiveDependency] ?? .incompatible
+                                nodeResult[transitiveDependency] ?? .incompatible
 
                             // Union our filters because multiple paths could lead to the same dependency (e.g. AVFoundation)
                             //  A --> (.ios) B --> C
                             //  A --> (.macos) D --> C
                             // C should have `[.ios, .macos]` set for filters to satisfy both paths
-                            stack[frameIndex].result[transitiveDependency] =
+                            nodeResult[transitiveDependency] =
                                 previousResult.combineWith(combinedCondition)
                         }
 
-                        stack[frameIndex].nextDependencyIndex += 1
-                        continue
                     }
 
-                    if activeDependencies.contains(dependency) {
-                        stack[frameIndex].nextDependencyIndex += 1
-                        continue
-                    }
-
-                    activeDependencies.insert(dependency)
-                    stack.append(
-                        ConditionMapTraversalFrame(
-                            node: dependency,
-                            dependencies: Array(graph.dependencies[dependency] ?? []),
-                            nextDependencyIndex: 0,
-                            result: [:]
-                        )
-                    )
-                } else {
                     for dependency in frame.dependencies {
-                        stack[frameIndex].result[dependency] =
+                        nodeResult[dependency] =
                             .condition(graph.dependencyConditions[(frame.node, dependency)])
                     }
 
-                    let completedFrame = stack.removeLast()
-                    result[completedFrame.node] = completedFrame.result
-                    completedDependencies.insert(completedFrame.node)
-                    activeDependencies.remove(completedFrame.node)
+                    result[frame.node] = nodeResult
+                    completedDependencies.insert(frame.node)
+                    activeDependencies.remove(frame.node)
+                    stack.removeLast()
                 }
             }
         }

--- a/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
@@ -67,6 +67,12 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         graphTraverser: GraphTraversing,
         cache: Cache
     ) -> StaticProducts {
+        struct StaticProductsFrame {
+            let dependency: GraphDependency
+            let dependencies: [GraphDependency]
+            var preOrderVisit: Bool
+        }
+
         if let cachedResult = cache.results(for: dependency) {
             return cachedResult
         }
@@ -290,12 +296,6 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 // MARK: - Helper Types
 
 extension StaticProductsGraphLinter {
-    private struct StaticProductsFrame {
-        let dependency: GraphDependency
-        let dependencies: [GraphDependency]
-        var preOrderVisit: Bool
-    }
-
     private struct StaticDependencyWarning: Hashable, Comparable {
         var staticProduct: GraphDependency
         var linkingDependencies: [GraphDependency]

--- a/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
@@ -71,13 +71,12 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             return cachedResult
         }
 
-        var activeDependencies = Set([dependency])
+        var activeDependencies = Set<GraphDependency>()
         var stack = [
             StaticProductsFrame(
                 dependency: dependency,
                 dependencies: dependencies(for: dependency, graphTraverser: graphTraverser),
-                nextDependencyIndex: 0,
-                results: StaticProducts()
+                preOrderVisit: true
             ),
         ]
 
@@ -85,45 +84,41 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.dependencies.count {
-                let childDependency = frame.dependencies[frame.nextDependencyIndex]
-
-                if let cachedResult = cache.results(for: childDependency) {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].results = cachedResult.merged(with: stack[frameIndex].results)
+            if frame.preOrderVisit {
+                guard
+                    cache.results(for: frame.dependency) == nil,
+                    activeDependencies.insert(frame.dependency).inserted
+                else {
+                    stack.removeLast()
                     continue
                 }
 
-                if activeDependencies.contains(childDependency) {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
-                }
-
-                activeDependencies.insert(childDependency)
-                stack.append(
-                    StaticProductsFrame(
-                        dependency: childDependency,
-                        dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
-                        nextDependencyIndex: 0,
-                        results: StaticProducts()
+                stack[frameIndex].preOrderVisit = false
+                for childDependency in frame.dependencies {
+                    stack.append(
+                        StaticProductsFrame(
+                            dependency: childDependency,
+                            dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
+                            preOrderVisit: true
+                        )
                     )
-                )
+                }
             } else {
-                let completedFrame = stack.removeLast()
+                var childResults = StaticProducts()
+                for childDependency in frame.dependencies {
+                    if let cachedResult = cache.results(for: childDependency) {
+                        childResults = cachedResult.merged(with: childResults)
+                    }
+                }
+
                 let results = finalize(
-                    results: completedFrame.results,
-                    for: completedFrame.dependency,
+                    results: childResults,
+                    for: frame.dependency,
                     graphTraverser: graphTraverser
                 )
-                cache.cache(results: results, for: completedFrame.dependency)
-                activeDependencies.remove(completedFrame.dependency)
-
-                if let parentFrameIndex = stack.indices.last {
-                    stack[parentFrameIndex].nextDependencyIndex += 1
-                    stack[parentFrameIndex].results = results.merged(with: stack[parentFrameIndex].results)
-                } else {
-                    return results
-                }
+                cache.cache(results: results, for: frame.dependency)
+                activeDependencies.remove(frame.dependency)
+                stack.removeLast()
             }
         }
 
@@ -298,8 +293,7 @@ extension StaticProductsGraphLinter {
     private struct StaticProductsFrame {
         let dependency: GraphDependency
         let dependencies: [GraphDependency]
-        var nextDependencyIndex: Int
-        var results: StaticProducts
+        var preOrderVisit: Bool
     }
 
     private struct StaticDependencyWarning: Hashable, Comparable {

--- a/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
@@ -34,8 +34,7 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
             let results = buildStaticProductsMap(
                 visiting: dependency,
                 graphTraverser: graphTraverser,
-                cache: cache,
-                config: config
+                cache: cache
             )
 
             warnings.formUnion( results.linked.flatMap {
@@ -66,23 +65,81 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
     private func buildStaticProductsMap(
         visiting dependency: GraphDependency,
         graphTraverser: GraphTraversing,
-        cache: Cache,
-        config: Config
+        cache: Cache
     ) -> StaticProducts {
         if let cachedResult = cache.results(for: dependency) {
             return cachedResult
         }
 
-        // Collect dependency results traversing the graph (dfs)
-        var results = dependencies(for: dependency, graphTraverser: graphTraverser).reduce(StaticProducts()) { results, dep in
-            buildStaticProductsMap(visiting: dep, graphTraverser: graphTraverser, cache: cache, config: config)
-                .merged(with: results)
+        var activeDependencies = Set([dependency])
+        var stack = [
+            StaticProductsFrame(
+                dependency: dependency,
+                dependencies: dependencies(for: dependency, graphTraverser: graphTraverser),
+                nextDependencyIndex: 0,
+                results: StaticProducts()
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.dependencies.count {
+                let childDependency = frame.dependencies[frame.nextDependencyIndex]
+
+                if let cachedResult = cache.results(for: childDependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].results = cachedResult.merged(with: stack[frameIndex].results)
+                    continue
+                }
+
+                if activeDependencies.contains(childDependency) {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
+                }
+
+                activeDependencies.insert(childDependency)
+                stack.append(
+                    StaticProductsFrame(
+                        dependency: childDependency,
+                        dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
+                        nextDependencyIndex: 0,
+                        results: StaticProducts()
+                    )
+                )
+            } else {
+                let completedFrame = stack.removeLast()
+                let results = finalize(
+                    results: completedFrame.results,
+                    for: completedFrame.dependency,
+                    graphTraverser: graphTraverser
+                )
+                cache.cache(results: results, for: completedFrame.dependency)
+                activeDependencies.remove(completedFrame.dependency)
+
+                if let parentFrameIndex = stack.indices.last {
+                    stack[parentFrameIndex].nextDependencyIndex += 1
+                    stack[parentFrameIndex].results = results.merged(with: stack[parentFrameIndex].results)
+                } else {
+                    return results
+                }
+            }
         }
+
+        return cache.results(for: dependency) ?? StaticProducts()
+    }
+
+    private func finalize(
+        results: StaticProducts,
+        for dependency: GraphDependency,
+        graphTraverser: GraphTraversing
+    ) -> StaticProducts {
+        var results = results
 
         // Static node case
         if isStaticProduct(dependency, graphTraverser: graphTraverser) {
             results.unlinked.insert(dependency)
-            cache.cache(results: results, for: dependency)
             return results
         }
 
@@ -97,11 +154,6 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         while let staticProduct = results.unlinked.popFirst() {
             results.linked[staticProduct, default: Set()].insert(dependency)
         }
-
-        cache.cache(
-            results: results,
-            for: dependency
-        )
 
         return results
     }
@@ -243,6 +295,13 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
 // MARK: - Helper Types
 
 extension StaticProductsGraphLinter {
+    private struct StaticProductsFrame {
+        let dependency: GraphDependency
+        let dependencies: [GraphDependency]
+        var nextDependencyIndex: Int
+        var results: StaticProducts
+    }
+
     private struct StaticDependencyWarning: Hashable, Comparable {
         var staticProduct: GraphDependency
         var linkingDependencies: [GraphDependency]

--- a/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
+++ b/Sources/GekoGenerator/Linter/StaticProductsGraphLinter.swift
@@ -25,16 +25,16 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
         config: Config
     ) -> Set<StaticDependencyWarning> {
         var warnings = Set<StaticDependencyWarning>()
-        let cache = Cache()
+        var cache: [GraphDependency: StaticProducts] = [:]
         for dependency in dependencies {
             // Skip already evaluated nodes
-            guard cache.results(for: dependency) == nil else {
+            guard cache[dependency] == nil else {
                 continue
             }
             let results = buildStaticProductsMap(
                 visiting: dependency,
                 graphTraverser: graphTraverser,
-                cache: cache
+                cache: &cache
             )
 
             warnings.formUnion( results.linked.flatMap {
@@ -65,83 +65,68 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
     private func buildStaticProductsMap(
         visiting dependency: GraphDependency,
         graphTraverser: GraphTraversing,
-        cache: Cache
+        cache: inout [GraphDependency: StaticProducts]
     ) -> StaticProducts {
-        struct StaticProductsFrame {
-            let dependency: GraphDependency
-            let dependencies: [GraphDependency]
-            var preOrderVisit: Bool
-        }
-
-        if let cachedResult = cache.results(for: dependency) {
+        if let cachedResult = cache[dependency] {
             return cachedResult
         }
 
-        var activeDependencies = Set<GraphDependency>()
-        var stack = [
-            StaticProductsFrame(
-                dependency: dependency,
-                dependencies: dependencies(for: dependency, graphTraverser: graphTraverser),
-                preOrderVisit: true
-            ),
-        ]
+        var stack = [(
+            dependency: dependency,
+            dependencies: dependencies(for: dependency, graphTraverser: graphTraverser),
+            preOrderVisit: true
+        )]
 
         while !stack.isEmpty {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
             if frame.preOrderVisit {
-                guard
-                    cache.results(for: frame.dependency) == nil,
-                    activeDependencies.insert(frame.dependency).inserted
-                else {
+                guard cache[frame.dependency] == nil else {
                     stack.removeLast()
                     continue
                 }
 
                 stack[frameIndex].preOrderVisit = false
+                cache[frame.dependency] = .init()
+
                 for childDependency in frame.dependencies {
-                    stack.append(
-                        StaticProductsFrame(
-                            dependency: childDependency,
-                            dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
-                            preOrderVisit: true
-                        )
-                    )
+                    stack.append((
+                        dependency: childDependency,
+                        dependencies: dependencies(for: childDependency, graphTraverser: graphTraverser),
+                        preOrderVisit: true
+                    ))
                 }
             } else {
-                var childResults = StaticProducts()
+                var results = StaticProducts()
                 for childDependency in frame.dependencies {
-                    if let cachedResult = cache.results(for: childDependency) {
-                        childResults = cachedResult.merged(with: childResults)
+                    if let cachedResult = cache[childDependency] {
+                        results = cachedResult.merged(with: results)
                     }
                 }
 
-                let results = finalize(
-                    results: childResults,
+                finalize(
+                    results: &results,
                     for: frame.dependency,
                     graphTraverser: graphTraverser
                 )
-                cache.cache(results: results, for: frame.dependency)
-                activeDependencies.remove(frame.dependency)
+                cache[frame.dependency] = results
                 stack.removeLast()
             }
         }
 
-        return cache.results(for: dependency) ?? StaticProducts()
+        return cache[dependency] ?? StaticProducts()
     }
 
     private func finalize(
-        results: StaticProducts,
+        results: inout StaticProducts,
         for dependency: GraphDependency,
         graphTraverser: GraphTraversing
-    ) -> StaticProducts {
-        var results = results
-
+    ) {
         // Static node case
         if isStaticProduct(dependency, graphTraverser: graphTraverser) {
             results.unlinked.insert(dependency)
-            return results
+            return
         }
 
         // Linking node case
@@ -149,14 +134,12 @@ class StaticProductsGraphLinter: StaticProductsGraphLinting {
               let dependencyTarget = graphTraverser.target(path: targetPath, name: targetName),
               dependencyTarget.target.canLinkStaticProducts()
         else {
-            return results
+            return
         }
 
         while let staticProduct = results.unlinked.popFirst() {
             results.linked[staticProduct, default: Set()].insert(dependency)
         }
-
-        return results
     }
 
     private func staticDependencyWarning(
@@ -331,21 +314,6 @@ extension StaticProductsGraphLinter {
                 unlinked: unlinked.union(other.unlinked),
                 linked: linked.merging(other.linked, uniquingKeysWith: { $0.union($1) })
             )
-        }
-    }
-
-    private class Cache {
-        private var cachedResults: [GraphDependency: StaticProducts] = [:]
-
-        func results(for dependency: GraphDependency) -> StaticProducts? {
-            cachedResults[dependency]
-        }
-
-        func cache(
-            results: StaticProducts,
-            for dependency: GraphDependency
-        ) {
-            cachedResults[dependency] = results
         }
     }
 }

--- a/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
@@ -56,7 +56,7 @@ public final class ModuleMapMapper: GraphMapping {
         let projectPath: AbsolutePath
         let targetName: String
     }
-    
+
     private struct DependencyMetadata: Hashable {
         let moduleMapPath: AbsolutePath?
         let headerSearchPaths: [String]
@@ -162,7 +162,6 @@ public final class ModuleMapMapper: GraphMapping {
             return
         }
 
-        var activeTargetIDs = Set<TargetID>()
         var stack = [
             DependenciesModuleMapsFrame(
                 target: target,
@@ -182,10 +181,6 @@ public final class ModuleMapMapper: GraphMapping {
                     continue
                 }
 
-                guard activeTargetIDs.insert(frameTargetID).inserted else {
-                    throw GraphError.unexpectedCycle
-                }
-
                 let resolvedDependencies = try frame.target.target.dependencies.compactMap { dependency in
                     try resolve(
                         dependency: dependency,
@@ -195,6 +190,7 @@ public final class ModuleMapMapper: GraphMapping {
                     )
                 }
 
+                targetToDependenciesMetadata[frameTargetID] = []
                 stack[frameIndex].resolvedDependencies = resolvedDependencies
                 stack[frameIndex].preOrderVisit = false
 
@@ -217,7 +213,6 @@ public final class ModuleMapMapper: GraphMapping {
 
                 let frameTargetID = targetID(for: frame.target)
                 targetToDependenciesMetadata[frameTargetID] = dependenciesMetadata
-                activeTargetIDs.remove(frameTargetID)
                 stack.removeLast()
             }
         }

--- a/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
@@ -62,6 +62,17 @@ public final class ModuleMapMapper: GraphMapping {
         let headerSearchPaths: [String]
     }
 
+    private struct DependenciesModuleMapsFrame {
+        let target: GraphTarget
+        var nextDependencyIndex: Int
+        var dependenciesMetadata: Set<DependencyMetadata>
+    }
+
+    private struct ResolvedDependency {
+        let project: Project
+        let target: GraphTarget
+    }
+
     public init() {}
 
     // swiftlint:disable function_body_length
@@ -74,6 +85,7 @@ public final class ModuleMapMapper: GraphMapping {
         for target in graphTraverser.allTargets().filter({ $0.project.projectType != .cocoapods }) {
             try dependenciesModuleMaps(
                 graph: graph,
+                graphTraverser: graphTraverser,
                 target: target,
                 targetToDependenciesMetadata: &targetToDependenciesMetadata
             )
@@ -140,83 +152,155 @@ public final class ModuleMapMapper: GraphMapping {
     /// The `targetToDependenciesMetadata` is also used as cache to avoid recomputing the set for already computed targets.
     private func dependenciesModuleMaps( // swiftlint:disable:this function_body_length
         graph: Graph,
+        graphTraverser: GraphTraverser,
         target: GraphTarget,
         targetToDependenciesMetadata: inout [TargetID: Set<DependencyMetadata>]
     ) throws {
-        let targetID = TargetID(projectPath: target.path, targetName: target.target.name)
-        if targetToDependenciesMetadata[targetID] != nil {
+        let rootTargetID = targetID(for: target)
+        if targetToDependenciesMetadata[rootTargetID] != nil {
             // already computed
             return
         }
-        let graphTraverser = GraphTraverser(graph: graph)
 
-        var dependenciesMetadata: Set<DependencyMetadata> = []
-        for dependency in target.target.dependencies {
-            let dependentProject: Project
-            let dependentTarget: GraphTarget
-            switch dependency {
-            case let .target(name, _, _):
-                guard let dependentTargetFromName = graphTraverser.target(path: target.path, name: name) else {
-                    throw ModuleMapMapperError.invalidTargetDependency(
-                        sourceProject: target.project.path,
-                        sourceTarget: target.target.name,
-                        dependentTarget: name
+        var activeTargetIDs = Set([rootTargetID])
+        var stack = [
+            DependenciesModuleMapsFrame(
+                target: target,
+                nextDependencyIndex: 0,
+                dependenciesMetadata: []
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextDependencyIndex < frame.target.target.dependencies.count {
+                let dependency = frame.target.target.dependencies[frame.nextDependencyIndex]
+
+                guard
+                    let resolvedDependency = try resolve(
+                        dependency: dependency,
+                        from: frame.target,
+                        graph: graph,
+                        graphTraverser: graphTraverser
                     )
-                }
-
-                guard dependentTargetFromName.project.projectType != .cocoapods else { continue }
-                dependentProject = target.project
-                dependentTarget = dependentTargetFromName
-            case let .project(name, path, _, _):
-                guard let dependentProjectFromPath = graph.projects[path],
-                      let dependentTargetFromName = graphTraverser.target(path: path, name: name)
                 else {
-                    throw ModuleMapMapperError.invalidProjectTargetDependency(
-                        sourceProject: target.project.path,
-                        sourceTarget: target.target.name,
-                        dependentProject: path,
-                        dependentTarget: name
-                    )
+                    stack[frameIndex].nextDependencyIndex += 1
+                    continue
                 }
-                guard dependentTargetFromName.project.projectType != .cocoapods else { continue }
-                dependentProject = dependentProjectFromPath
-                dependentTarget = dependentTargetFromName
-            case .framework, .xcframework, .library, .sdk, .xctest, .bundle, .external, .local:
-                continue
-            }
 
-            try dependenciesModuleMaps(
-                graph: graph,
-                target: dependentTarget,
-                targetToDependenciesMetadata: &targetToDependenciesMetadata
-            )
+                let dependencyTargetID = targetID(for: resolvedDependency.target)
+                if let indirectDependencyMetadata = targetToDependenciesMetadata[dependencyTargetID] {
+                    stack[frameIndex].nextDependencyIndex += 1
+                    stack[frameIndex].dependenciesMetadata.formUnion(indirectDependencyMetadata)
+                    stack[frameIndex].dependenciesMetadata.insert(
+                        try dependencyMetadata(for: resolvedDependency)
+                    )
+                    continue
+                }
 
-            // direct dependency module map
-            let dependencyModuleMapPath: AbsolutePath?
+                if activeTargetIDs.contains(dependencyTargetID) {
+                    throw GraphError.unexpectedCycle
+                }
 
-            if case let .string(dependencyModuleMap) = dependentTarget.target.settings?.base[Self.modulemapFileSetting], dependentTarget.project.projectType == .spm {
-                let pathString = dependentProject.path.pathString
-                dependencyModuleMapPath = try AbsolutePath(
-                    validating: dependencyModuleMap
-                        .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
-                        .replacingOccurrences(of: "$(SRCROOT)", with: pathString)
-                        .replacingOccurrences(of: "$(SOURCE_ROOT)", with: pathString)
+                activeTargetIDs.insert(dependencyTargetID)
+                stack.append(
+                    DependenciesModuleMapsFrame(
+                        target: resolvedDependency.target,
+                        nextDependencyIndex: 0,
+                        dependenciesMetadata: []
+                    )
                 )
             } else {
-                dependencyModuleMapPath = nil
+                let completedFrame = stack.removeLast()
+                let completedTargetID = targetID(for: completedFrame.target)
+                targetToDependenciesMetadata[completedTargetID] = completedFrame.dependenciesMetadata
+                activeTargetIDs.remove(completedTargetID)
             }
+        }
+    }
 
-            var headerSearchPaths: [String]
-            switch dependentTarget.target.settings?.base[Self.headerSearchPaths] ?? .array([]) {
-            case let .array(values):
-                headerSearchPaths = values
-            case let .string(value):
-                headerSearchPaths = [value]
+    private func targetID(for target: GraphTarget) -> TargetID {
+        TargetID(projectPath: target.path, targetName: target.target.name)
+    }
+
+    private func resolve(
+        dependency: TargetDependency,
+        from target: GraphTarget,
+        graph: Graph,
+        graphTraverser: GraphTraverser
+    ) throws -> ResolvedDependency? {
+        let dependentProject: Project
+        let dependentTarget: GraphTarget
+
+        switch dependency {
+        case let .target(name, _, _):
+            guard let resolvedTarget = graphTraverser.target(path: target.path, name: name) else {
+                throw ModuleMapMapperError.invalidTargetDependency(
+                    sourceProject: target.project.path,
+                    sourceTarget: target.target.name,
+                    dependentTarget: name
+                )
             }
+            dependentProject = target.project
+            dependentTarget = resolvedTarget
 
-            headerSearchPaths = headerSearchPaths.map {
-                let pathString = dependentProject.path.pathString
-                return (
+        case let .project(name, path, _, _):
+            guard
+                let resolvedProject = graph.projects[path],
+                let resolvedTarget = graphTraverser.target(path: path, name: name)
+            else {
+                throw ModuleMapMapperError.invalidProjectTargetDependency(
+                    sourceProject: target.project.path,
+                    sourceTarget: target.target.name,
+                    dependentProject: path,
+                    dependentTarget: name
+                )
+            }
+            dependentProject = resolvedProject
+            dependentTarget = resolvedTarget
+
+        case .framework, .xcframework, .library, .sdk, .xctest, .bundle, .external, .local:
+            return nil
+        }
+
+        guard dependentTarget.project.projectType != .cocoapods else {
+            return nil
+        }
+
+        return ResolvedDependency(project: dependentProject, target: dependentTarget)
+    }
+
+    private func dependencyMetadata(for dependency: ResolvedDependency) throws -> DependencyMetadata {
+        let dependencyModuleMapPath: AbsolutePath?
+        let pathString = dependency.project.path.pathString
+
+        if case let .string(dependencyModuleMap) = dependency.target.target.settings?.base[Self.modulemapFileSetting],
+           dependency.target.project.projectType == .spm
+        {
+            dependencyModuleMapPath = try AbsolutePath(
+                validating: dependencyModuleMap
+                    .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
+                    .replacingOccurrences(of: "$(SRCROOT)", with: pathString)
+                    .replacingOccurrences(of: "$(SOURCE_ROOT)", with: pathString)
+            )
+        } else {
+            dependencyModuleMapPath = nil
+        }
+
+        let headerSearchPaths: [String]
+        switch dependency.target.target.settings?.base[Self.headerSearchPaths] ?? .array([]) {
+        case let .array(values):
+            headerSearchPaths = values
+        case let .string(value):
+            headerSearchPaths = [value]
+        }
+
+        return DependencyMetadata(
+            moduleMapPath: dependencyModuleMapPath,
+            headerSearchPaths: headerSearchPaths.map {
+                (
                     try? AbsolutePath(
                         validating: $0
                             .replacingOccurrences(of: "$(PROJECT_DIR)", with: pathString)
@@ -225,22 +309,7 @@ public final class ModuleMapMapper: GraphMapping {
                     ).pathString
                 ) ?? $0
             }
-
-            // indirect dependency module maps
-            let dependentTargetID = TargetID(projectPath: dependentProject.path, targetName: dependentTarget.target.name)
-            if let indirectDependencyMetadata = targetToDependenciesMetadata[dependentTargetID] {
-                dependenciesMetadata.formUnion(indirectDependencyMetadata)
-            }
-
-            dependenciesMetadata.insert(
-                DependencyMetadata(
-                    moduleMapPath: dependencyModuleMapPath,
-                    headerSearchPaths: headerSearchPaths
-                )
-            )
-        }
-
-        targetToDependenciesMetadata[targetID] = dependenciesMetadata
+        )
     }
 
     private func updatedHeaderSearchPaths(

--- a/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
@@ -67,12 +67,6 @@ public final class ModuleMapMapper: GraphMapping {
         let target: GraphTarget
     }
 
-    private struct DependenciesModuleMapsFrame {
-        let target: GraphTarget
-        var resolvedDependencies: [ResolvedDependency]
-        var preOrderVisit: Bool
-    }
-
     public init() {}
 
     // swiftlint:disable function_body_length
@@ -156,6 +150,12 @@ public final class ModuleMapMapper: GraphMapping {
         target: GraphTarget,
         targetToDependenciesMetadata: inout [TargetID: Set<DependencyMetadata>]
     ) throws {
+        struct DependenciesModuleMapsFrame {
+            let target: GraphTarget
+            var resolvedDependencies: [ResolvedDependency]
+            var preOrderVisit: Bool
+        }
+
         let rootTargetID = targetID(for: target)
         if targetToDependenciesMetadata[rootTargetID] != nil {
             // already computed

--- a/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
+++ b/Sources/GekoGenerator/Mappers/ModuleMapMapper.swift
@@ -62,15 +62,15 @@ public final class ModuleMapMapper: GraphMapping {
         let headerSearchPaths: [String]
     }
 
-    private struct DependenciesModuleMapsFrame {
-        let target: GraphTarget
-        var nextDependencyIndex: Int
-        var dependenciesMetadata: Set<DependencyMetadata>
-    }
-
     private struct ResolvedDependency {
         let project: Project
         let target: GraphTarget
+    }
+
+    private struct DependenciesModuleMapsFrame {
+        let target: GraphTarget
+        var resolvedDependencies: [ResolvedDependency]
+        var preOrderVisit: Bool
     }
 
     public init() {}
@@ -162,12 +162,12 @@ public final class ModuleMapMapper: GraphMapping {
             return
         }
 
-        var activeTargetIDs = Set([rootTargetID])
+        var activeTargetIDs = Set<TargetID>()
         var stack = [
             DependenciesModuleMapsFrame(
                 target: target,
-                nextDependencyIndex: 0,
-                dependenciesMetadata: []
+                resolvedDependencies: [],
+                preOrderVisit: true
             ),
         ]
 
@@ -175,48 +175,50 @@ public final class ModuleMapMapper: GraphMapping {
             let frameIndex = stack.count - 1
             let frame = stack[frameIndex]
 
-            if frame.nextDependencyIndex < frame.target.target.dependencies.count {
-                let dependency = frame.target.target.dependencies[frame.nextDependencyIndex]
+            if frame.preOrderVisit {
+                let frameTargetID = targetID(for: frame.target)
+                guard targetToDependenciesMetadata[frameTargetID] == nil else {
+                    stack.removeLast()
+                    continue
+                }
 
-                guard
-                    let resolvedDependency = try resolve(
+                guard activeTargetIDs.insert(frameTargetID).inserted else {
+                    throw GraphError.unexpectedCycle
+                }
+
+                let resolvedDependencies = try frame.target.target.dependencies.compactMap { dependency in
+                    try resolve(
                         dependency: dependency,
                         from: frame.target,
                         graph: graph,
                         graphTraverser: graphTraverser
                     )
-                else {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    continue
                 }
 
-                let dependencyTargetID = targetID(for: resolvedDependency.target)
-                if let indirectDependencyMetadata = targetToDependenciesMetadata[dependencyTargetID] {
-                    stack[frameIndex].nextDependencyIndex += 1
-                    stack[frameIndex].dependenciesMetadata.formUnion(indirectDependencyMetadata)
-                    stack[frameIndex].dependenciesMetadata.insert(
-                        try dependencyMetadata(for: resolvedDependency)
+                stack[frameIndex].resolvedDependencies = resolvedDependencies
+                stack[frameIndex].preOrderVisit = false
+
+                for resolvedDependency in resolvedDependencies.reversed() {
+                    stack.append(
+                        DependenciesModuleMapsFrame(
+                            target: resolvedDependency.target,
+                            resolvedDependencies: [],
+                            preOrderVisit: true
+                        )
                     )
-                    continue
                 }
-
-                if activeTargetIDs.contains(dependencyTargetID) {
-                    throw GraphError.unexpectedCycle
-                }
-
-                activeTargetIDs.insert(dependencyTargetID)
-                stack.append(
-                    DependenciesModuleMapsFrame(
-                        target: resolvedDependency.target,
-                        nextDependencyIndex: 0,
-                        dependenciesMetadata: []
-                    )
-                )
             } else {
-                let completedFrame = stack.removeLast()
-                let completedTargetID = targetID(for: completedFrame.target)
-                targetToDependenciesMetadata[completedTargetID] = completedFrame.dependenciesMetadata
-                activeTargetIDs.remove(completedTargetID)
+                var dependenciesMetadata = Set<DependencyMetadata>()
+                for resolvedDependency in frame.resolvedDependencies {
+                    let dependencyTargetID = targetID(for: resolvedDependency.target)
+                    dependenciesMetadata.formUnion(targetToDependenciesMetadata[dependencyTargetID] ?? [])
+                    dependenciesMetadata.insert(try dependencyMetadata(for: resolvedDependency))
+                }
+
+                let frameTargetID = targetID(for: frame.target)
+                targetToDependenciesMetadata[frameTargetID] = dependenciesMetadata
+                activeTargetIDs.remove(frameTargetID)
+                stack.removeLast()
             }
         }
     }

--- a/Sources/GekoSupport/Process/GraphAlgorithms.swift
+++ b/Sources/GekoSupport/Process/GraphAlgorithms.swift
@@ -13,12 +13,6 @@ public enum GraphError: Error {
     case unexpectedCycle
 }
 
-private struct GraphTraversalFrame<Node> {
-    let node: Node
-    let successors: [Node]
-    var nextSuccessorIndex: Int
-}
-
 /// Compute the transitive closure of an input node set.
 ///
 /// - Note: The relation is *not* assumed to be reflexive; i.e. the result will
@@ -29,6 +23,9 @@ public func transitiveClosure<T>(
 ) rethrows -> Set<T> {
     var result = Set<T>()
 
+    // The queue of items to recursively visit.
+    //
+    // We add items post-collation to avoid unnecessary queue operations.
     var queue = nodes
     while let node = queue.popLast() {
         for succ in try successors(node) {
@@ -65,49 +62,44 @@ public func topologicalSort<T: Hashable>(
     var active = Set<T>()
     var result: [T] = []
 
-    for node in nodes {
-        guard visited.insert(node).inserted else {
-            continue
-        }
+    var stack: [(node: T, preOrderVisit: Bool)] = []
+    // populate stack in the reverse order to keep original ordering
+    for i in stride(from: nodes.count - 1, through: 0, by: -1) {
+        stack.append((
+            node: nodes[i],
+            preOrderVisit: true
+        ))
+    }
 
-        active.insert(node)
-        var stack = [
-            GraphTraversalFrame(
-                node: node,
-                successors: try successors(node),
-                nextSuccessorIndex: 0
-            ),
-        ]
+    // for node in nodes {
+    while !stack.isEmpty {
+        let frameIndex = stack.count - 1
+        let frame = stack[frameIndex]
 
-        while !stack.isEmpty {
-            let frameIndex = stack.count - 1
-            let frame = stack[frameIndex]
+        if frame.preOrderVisit {
+            guard visited.insert(frame.node).inserted else {
+                stack.removeLast()
+                continue
+            }
 
-            if frame.nextSuccessorIndex < frame.successors.count {
-                let successor = frame.successors[frame.nextSuccessorIndex]
-                stack[frameIndex].nextSuccessorIndex += 1
+            stack[frameIndex].preOrderVisit = false
+            active.insert(frame.node)
 
+            let successors = try successors(frame.node)
+            // add successors to stack in reverse order to keep tree traversing order the same as successor list
+            for i in stride(from: successors.count - 1, through: 0, by: -1) {
                 // An edge to an active node closes a cycle in the current DFS path.
-                if active.contains(successor) {
+                if active.contains(successors[i]) {
                     throw GraphError.unexpectedCycle
                 }
 
-                if visited.insert(successor).inserted {
-                    active.insert(successor)
-                    stack.append(
-                        GraphTraversalFrame(
-                            node: successor,
-                            successors: try successors(successor),
-                            nextSuccessorIndex: 0
-                        )
-                    )
-                }
-            } else {
-                // Append in postorder to preserve the ordering of the recursive implementation.
-                result.append(frame.node)
-                active.remove(frame.node)
-                stack.removeLast()
+                stack.append((node: successors[i], preOrderVisit: true))
             }
+        } else {
+            // Append in postorder to preserve the ordering of the recursive implementation.
+            result.append(frame.node)
+            active.remove(frame.node)
+            stack.removeLast()
         }
     }
 
@@ -129,30 +121,36 @@ public func findCycle<T: Hashable>(
     successors: (T) throws -> [T]
 ) rethrows -> (path: [T], cycle: [T])? {
     var validNodes = Set<T>()
+    var path: [T] = []
+    // Mirrors `path` and provides the cycle start index when a back edge is found.
+    var activeNodeIndices: [T: Int] = [:]
 
-    for node in nodes {
-        guard !validNodes.contains(node) else {
-            continue
-        }
+    var stack: [(node: T, preOrderVisit: Bool)] = []
+    // populate stack in the reverse order to keep original ordering
+    for i in stride(from: nodes.count - 1, through: 0, by: -1) {
+        stack.append((
+            node: nodes[i],
+            preOrderVisit: true
+        ))
+    }
 
-        var path = [node]
-        // Mirrors `path` and provides the cycle start index when a back edge is found.
-        var activeNodeIndices = [node: 0]
-        var stack = [
-            GraphTraversalFrame(
-                node: node,
-                successors: try successors(node),
-                nextSuccessorIndex: 0
-            ),
-        ]
+    while !stack.isEmpty {
+        let frameIndex = stack.count - 1
+        let frame = stack[frameIndex]
 
-        while !stack.isEmpty {
-            let frameIndex = stack.count - 1
-            let frame = stack[frameIndex]
+        if frame.preOrderVisit {
+            guard !validNodes.contains(frame.node) else {
+                stack.removeLast()
+                continue
+            }
 
-            if frame.nextSuccessorIndex < frame.successors.count {
-                let successor = frame.successors[frame.nextSuccessorIndex]
-                stack[frameIndex].nextSuccessorIndex += 1
+            stack[frameIndex].preOrderVisit = false
+            activeNodeIndices[frame.node] = path.count
+            path.append(frame.node)
+
+            let successors = try successors(frame.node)
+            for i in stride(from: successors.count - 1, through: 0, by: -1) {
+                let successor = successors[i]
 
                 if let cycleStartIndex = activeNodeIndices[successor] {
                     return (
@@ -161,25 +159,15 @@ public func findCycle<T: Hashable>(
                     )
                 }
 
-                guard !validNodes.contains(successor) else {
-                    continue
-                }
+                guard !validNodes.contains(successor) else { continue }
 
-                activeNodeIndices[successor] = path.count
-                path.append(successor)
-                stack.append(
-                    GraphTraversalFrame(
-                        node: successor,
-                        successors: try successors(successor),
-                        nextSuccessorIndex: 0
-                    )
-                )
-            } else {
-                validNodes.insert(frame.node)
-                activeNodeIndices.removeValue(forKey: frame.node)
-                path.removeLast()
-                stack.removeLast()
+                stack.append((node: successor, preOrderVisit: true))
             }
+        } else {
+            validNodes.insert(frame.node)
+            activeNodeIndices.removeValue(forKey: frame.node)
+            path.removeLast()
+            stack.removeLast()
         }
     }
 

--- a/Sources/GekoSupport/Process/GraphAlgorithms.swift
+++ b/Sources/GekoSupport/Process/GraphAlgorithms.swift
@@ -71,7 +71,6 @@ public func topologicalSort<T: Hashable>(
         ))
     }
 
-    // for node in nodes {
     while !stack.isEmpty {
         let frameIndex = stack.count - 1
         let frame = stack[frameIndex]

--- a/Sources/GekoSupport/Process/GraphAlgorithms.swift
+++ b/Sources/GekoSupport/Process/GraphAlgorithms.swift
@@ -13,6 +13,12 @@ public enum GraphError: Error {
     case unexpectedCycle
 }
 
+private struct GraphTraversalFrame<Node> {
+    let node: Node
+    let successors: [Node]
+    var nextSuccessorIndex: Int
+}
+
 /// Compute the transitive closure of an input node set.
 ///
 /// - Note: The relation is *not* assumed to be reflexive; i.e. the result will
@@ -23,9 +29,6 @@ public func transitiveClosure<T>(
 ) rethrows -> Set<T> {
     var result = Set<T>()
 
-    // The queue of items to recursively visit.
-    //
-    // We add items post-collation to avoid unnecessary queue operations.
     var queue = nodes
     while let node = queue.popLast() {
         for succ in try successors(node) {
@@ -58,42 +61,54 @@ public func transitiveClosure<T>(
 public func topologicalSort<T: Hashable>(
     _ nodes: [T], successors: (T) throws -> [T]
 ) throws -> [T] {
-    // Implements a topological sort via recursion and reverse postorder DFS.
-    func visit(_ node: T,
-               _ stack: inout OrderedSet<T>, _ visited: inout Set<T>, _ result: inout [T],
-               _ successors: (T) throws -> [T]) throws {
-        // Mark this node as visited -- we are done if it already was.
-        if !visited.insert(node).inserted {
-            return
-        }
-
-        // Otherwise, visit each adjacent node.
-        for succ in try successors(node) {
-            guard stack.append(succ) else {
-                // If the successor is already in this current stack, we have found a cycle.
-                //
-                // FIXME: We could easily include information on the cycle we found here.
-                throw GraphError.unexpectedCycle
-            }
-            try visit(succ, &stack, &visited, &result, successors)
-            let popped = stack.removeLast()
-            assert(popped == succ)
-        }
-
-        // Add to the result.
-        result.append(node)
-    }
-
-    // FIXME: This should use a stack not recursion.
     var visited = Set<T>()
-    var result = [T]()
-    var stack = OrderedSet<T>()
+    var active = Set<T>()
+    var result: [T] = []
+
     for node in nodes {
-        precondition(stack.isEmpty)
-        stack.append(node)
-        try visit(node, &stack, &visited, &result, successors)
-        let popped = stack.removeLast()
-        assert(popped == node)
+        guard visited.insert(node).inserted else {
+            continue
+        }
+
+        active.insert(node)
+        var stack = [
+            GraphTraversalFrame(
+                node: node,
+                successors: try successors(node),
+                nextSuccessorIndex: 0
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextSuccessorIndex < frame.successors.count {
+                let successor = frame.successors[frame.nextSuccessorIndex]
+                stack[frameIndex].nextSuccessorIndex += 1
+
+                // An edge to an active node closes a cycle in the current DFS path.
+                if active.contains(successor) {
+                    throw GraphError.unexpectedCycle
+                }
+
+                if visited.insert(successor).inserted {
+                    active.insert(successor)
+                    stack.append(
+                        GraphTraversalFrame(
+                            node: successor,
+                            successors: try successors(successor),
+                            nextSuccessorIndex: 0
+                        )
+                    )
+                }
+            } else {
+                // Append in postorder to preserve the ordering of the recursive implementation.
+                result.append(frame.node)
+                active.remove(frame.node)
+                stack.removeLast()
+            }
+        }
     }
 
     return result.reversed()
@@ -113,38 +128,60 @@ public func findCycle<T: Hashable>(
     _ nodes: [T],
     successors: (T) throws -> [T]
 ) rethrows -> (path: [T], cycle: [T])? {
-    // Ordered set to hold the current traversed path.
-    var path = OrderedSet<T>()
     var validNodes = Set<T>()
 
-    // Function to visit nodes recursively.
-    // FIXME: Convert to stack.
-    func visit(_ node: T, _ successors: (T) throws -> [T]) rethrows -> (path: [T], cycle: [T])? {
-        if validNodes.contains(node) { return nil }
-        
-        // If this node is already in the current path then we have found a cycle.
-        if !path.append(node) {
-            let index = path.firstIndex(of: node)!
-            return (Array(path[path.startIndex..<index]), Array(path[index..<path.endIndex]))
+    for node in nodes {
+        guard !validNodes.contains(node) else {
+            continue
         }
 
-        for succ in try successors(node) {
-            if let cycle = try visit(succ, successors) {
-                return cycle
+        var path = [node]
+        // Mirrors `path` and provides the cycle start index when a back edge is found.
+        var activeNodeIndices = [node: 0]
+        var stack = [
+            GraphTraversalFrame(
+                node: node,
+                successors: try successors(node),
+                nextSuccessorIndex: 0
+            ),
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.count - 1
+            let frame = stack[frameIndex]
+
+            if frame.nextSuccessorIndex < frame.successors.count {
+                let successor = frame.successors[frame.nextSuccessorIndex]
+                stack[frameIndex].nextSuccessorIndex += 1
+
+                if let cycleStartIndex = activeNodeIndices[successor] {
+                    return (
+                        path: Array(path[..<cycleStartIndex]),
+                        cycle: Array(path[cycleStartIndex...])
+                    )
+                }
+
+                guard !validNodes.contains(successor) else {
+                    continue
+                }
+
+                activeNodeIndices[successor] = path.count
+                path.append(successor)
+                stack.append(
+                    GraphTraversalFrame(
+                        node: successor,
+                        successors: try successors(successor),
+                        nextSuccessorIndex: 0
+                    )
+                )
+            } else {
+                validNodes.insert(frame.node)
+                activeNodeIndices.removeValue(forKey: frame.node)
+                path.removeLast()
+                stack.removeLast()
             }
         }
-        // No cycle found for this node, remove it from the path.
-        let item = path.removeLast()
-        assert(item == node)
-        validNodes.insert(node)
-        return nil
     }
 
-    for node in nodes {
-        if let cycle = try visit(node, successors) {
-            return cycle
-        }
-    }
-    // Couldn't find any cycle in the graph.
     return nil
 }

--- a/Tests/GekoCacheTests/Utilities/SwiftModulesBuilderTests.swift
+++ b/Tests/GekoCacheTests/Utilities/SwiftModulesBuilderTests.swift
@@ -37,9 +37,11 @@ final class SwiftModulesBuilderTests: XCTestCase {
         )
 
         // When
-        let result = SwiftModulesBuilder().transitiveXCFrameworkDependencies(
-            dependencyPaths: [pathA],
-            graph: graph
+        var result: [AbsolutePath: (GraphDependency, Set<GraphDependency>)] = [:]
+        SwiftModulesBuilder().transitiveXCFrameworkDependencies(
+            dependencyPath: pathA,
+            graph: graph,
+            visitedNodes: &result
         )
 
         // Then
@@ -78,10 +80,14 @@ final class SwiftModulesBuilderTests: XCTestCase {
         )
 
         // When
-        let result = SwiftModulesBuilder().transitiveXCFrameworkDependencies(
-            dependencyPaths: [pathA, pathB],
-            graph: graph
-        )
+        var result: [AbsolutePath: (GraphDependency, Set<GraphDependency>)] = [:]
+        [pathA, pathB].forEach {
+            SwiftModulesBuilder().transitiveXCFrameworkDependencies(
+                dependencyPath: $0,
+                graph: graph,
+                visitedNodes: &result
+            )
+        }
 
         // Then
         XCTAssertEqual(result[pathA]?.1, Set([sharedXCFramework, library]))

--- a/Tests/GekoCacheTests/Utilities/SwiftModulesBuilderTests.swift
+++ b/Tests/GekoCacheTests/Utilities/SwiftModulesBuilderTests.swift
@@ -1,0 +1,91 @@
+import GekoCore
+import GekoCoreTesting
+import GekoGraph
+import GekoSupport
+import ProjectDescription
+import XCTest
+
+@testable import GekoCache
+@testable import GekoSupportTesting
+
+final class SwiftModulesBuilderTests: XCTestCase {
+    func test_transitiveXCFrameworkDependencies_collectsDirectAndTransitiveDependencies() {
+        // Given
+        let pathA: AbsolutePath = "/A.xcframework"
+        let pathB: AbsolutePath = "/B.xcframework"
+        let pathC: AbsolutePath = "/C.xcframework"
+        let xcframeworkA = GraphDependency.testXCFramework(path: pathA)
+        let xcframeworkB = GraphDependency.testXCFramework(path: pathB)
+        let xcframeworkC = GraphDependency.testXCFramework(path: pathC)
+        let library = GraphDependency.testLibrary(path: "/libDependency.a")
+        let framework = GraphDependency.testFramework(path: "/Dependency.framework")
+        let sdk = GraphDependency.testSDK(name: "Foundation")
+        let graph = Graph.test(
+            dependencies: [
+                xcframeworkA: [xcframeworkB, library],
+                xcframeworkB: [xcframeworkC, sdk],
+                xcframeworkC: [framework],
+                library: [],
+                framework: [],
+                sdk: [],
+            ],
+            xcframeworks: [
+                pathA: xcframeworkA,
+                pathB: xcframeworkB,
+                pathC: xcframeworkC,
+            ]
+        )
+
+        // When
+        let result = SwiftModulesBuilder().transitiveXCFrameworkDependencies(
+            dependencyPaths: [pathA],
+            graph: graph
+        )
+
+        // Then
+        XCTAssertEqual(result[pathA]?.0, xcframeworkA)
+        XCTAssertEqual(
+            result[pathA]?.1,
+            Set([xcframeworkB, xcframeworkC, library, framework, sdk])
+        )
+        XCTAssertEqual(result[pathB]?.0, xcframeworkB)
+        XCTAssertEqual(result[pathB]?.1, Set([xcframeworkC, framework, sdk]))
+        XCTAssertEqual(result[pathC]?.0, xcframeworkC)
+        XCTAssertEqual(result[pathC]?.1, Set([framework]))
+    }
+
+    func test_transitiveXCFrameworkDependencies_collectsSharedDependencyForEveryRoot() {
+        // Given
+        let pathA: AbsolutePath = "/A.xcframework"
+        let pathB: AbsolutePath = "/B.xcframework"
+        let pathShared: AbsolutePath = "/Shared.xcframework"
+        let xcframeworkA = GraphDependency.testXCFramework(path: pathA)
+        let xcframeworkB = GraphDependency.testXCFramework(path: pathB)
+        let sharedXCFramework = GraphDependency.testXCFramework(path: pathShared)
+        let library = GraphDependency.testLibrary(path: "/libShared.a")
+        let graph = Graph.test(
+            dependencies: [
+                xcframeworkA: [sharedXCFramework],
+                xcframeworkB: [sharedXCFramework],
+                sharedXCFramework: [library],
+                library: [],
+            ],
+            xcframeworks: [
+                pathA: xcframeworkA,
+                pathB: xcframeworkB,
+                pathShared: sharedXCFramework,
+            ]
+        )
+
+        // When
+        let result = SwiftModulesBuilder().transitiveXCFrameworkDependencies(
+            dependencyPaths: [pathA, pathB],
+            graph: graph
+        )
+
+        // Then
+        XCTAssertEqual(result[pathA]?.1, Set([sharedXCFramework, library]))
+        XCTAssertEqual(result[pathB]?.1, Set([sharedXCFramework, library]))
+        XCTAssertEqual(result[pathShared]?.1, Set([library]))
+    }
+}

--- a/Tests/GekoCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/GekoCoreTests/Graph/GraphTraverserTests.swift
@@ -5328,6 +5328,53 @@ final class GraphTraverserTests: GekoUnitTestCase {
         ])
     }
 
+    func test_allSwiftMacroTargets_handlesLongDependencyChainWithoutRecursion() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let targetCount = 20_000
+        let macroTargetIndex = targetCount - 1
+        let targetWithMacroIndex = macroTargetIndex - 1
+        let targets = (0 ..< targetCount).map { index in
+            Target.test(
+                name: "Target\(index)",
+                product: index == macroTargetIndex ? .macro : .staticFramework
+            )
+        }
+        let project = Project.test(path: path, targets: targets)
+        let graphTargets = Dictionary(uniqueKeysWithValues: targets.map { ($0.name, $0) })
+        let dependencies = Dictionary(uniqueKeysWithValues: (0 ..< targetCount).map { index in
+            let dependency = GraphDependency.target(name: targets[index].name, path: path)
+            let directDependencies: Set<GraphDependency> = index == macroTargetIndex
+                ? []
+                : [.target(name: targets[index + 1].name, path: path)]
+            return (dependency, directDependencies)
+        })
+        let subject = GraphTraverser(
+            graph: .test(
+                path: path,
+                projects: [path: project],
+                targets: [path: graphTargets],
+                dependencies: dependencies
+            )
+        )
+
+        // When
+        let result = subject.allSwiftMacroTargets(path: path, name: targets[0].name)
+
+        // Then
+        // The method returns the linkable target that directly depends on the macro target.
+        XCTAssertEqual(
+            result,
+            Set([
+                GraphTarget(
+                    path: path,
+                    target: targets[targetWithMacroIndex],
+                    project: project
+                ),
+            ])
+        )
+    }
+
     func test_directTargetDependenciesWithConditions() throws {
         // Given
         let app = Target.test(name: "App", destinations: [.iPhone], product: .app)
@@ -6057,6 +6104,87 @@ final class GraphTraverserTests: GekoUnitTestCase {
             if case let .project(_, path, _, _) = dep { return path.pathString == unusedProjectPath.pathString }
             return false
         })
+    }
+
+    func test_warmup_handlesLongDependencyChainWithoutRecursion() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let nodeCount = 1_000
+        let nodes = (0 ..< nodeCount).map {
+            GraphDependency.target(name: "Target\($0)", path: path)
+        }
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [
+            nodes[nodeCount - 1]: [],
+        ]
+        for index in 0 ..< nodeCount - 1 {
+            dependencies[nodes[index]] = [nodes[index + 1]]
+        }
+        let subject = GraphTraverser(
+            graph: .test(
+                path: path,
+                dependencies: dependencies
+            )
+        )
+
+        // When
+        subject.warmup()
+
+        // Then
+        XCTAssertEqual(
+            subject.combinedCondition(to: nodes[nodeCount - 1], from: nodes[0]),
+            .condition(nil)
+        )
+    }
+
+    func test_allTargetDependencies_returnsAllReachableTargetsInBranchingGraph() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let root = Target.test(name: "Root")
+        let featureA = Target.test(name: "FeatureA")
+        let featureB = Target.test(name: "FeatureB")
+        let shared = Target.test(name: "Shared")
+        let leaf = Target.test(name: "Leaf")
+        let targets = [root, featureA, featureB, shared, leaf]
+        let project = Project.test(path: path, targets: targets)
+
+        let rootDependency = GraphDependency.target(name: root.name, path: path)
+        let featureADependency = GraphDependency.target(name: featureA.name, path: path)
+        let featureBDependency = GraphDependency.target(name: featureB.name, path: path)
+        let sharedDependency = GraphDependency.target(name: shared.name, path: path)
+        let leafDependency = GraphDependency.target(name: leaf.name, path: path)
+        let precompiledDependency = GraphDependency.testFramework(path: "/Precompiled.framework")
+
+        let subject = GraphTraverser(
+            graph: .test(
+                path: path,
+                projects: [path: project],
+                targets: [
+                    path: Dictionary(uniqueKeysWithValues: targets.map { ($0.name, $0) }),
+                ],
+                dependencies: [
+                    rootDependency: [featureADependency, featureBDependency, precompiledDependency],
+                    featureADependency: [sharedDependency],
+                    featureBDependency: [sharedDependency],
+                    sharedDependency: [leafDependency],
+                    leafDependency: [],
+                    precompiledDependency: [],
+                ]
+            )
+        )
+
+        // When
+        let result = subject.allTargetDependencies(path: path, name: root.name)
+
+        // Then
+        XCTAssertEqual(
+            result,
+            Set([
+                GraphTarget(path: path, target: featureA, project: project),
+                GraphTarget(path: path, target: featureB, project: project),
+                GraphTarget(path: path, target: shared, project: project),
+                GraphTarget(path: path, target: leaf, project: project),
+            ])
+        )
     }
 
     // MARK: - Helpers

--- a/Tests/GekoCoreTests/Graph/GraphTraverserTests.swift
+++ b/Tests/GekoCoreTests/Graph/GraphTraverserTests.swift
@@ -2724,6 +2724,54 @@ final class GraphTraverserTests: GekoUnitTestCase {
         )
     }
 
+    func test_linkableDependencies_handlesLongDynamicDependencyChainWithoutRecursion() throws {
+        // Given
+        let path: AbsolutePath = "/project"
+        let frameworkCount = 20_000
+        let app = Target.test(name: "App", product: .app)
+        let frameworks = (0 ..< frameworkCount).map {
+            Target.test(name: "Framework\($0)", product: .framework)
+        }
+        let targets = [app] + frameworks
+        let project = Project.test(path: path, targets: targets)
+        let frameworkDependencies = frameworks.map {
+            GraphDependency.target(name: $0.name, path: path)
+        }
+
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [
+            .target(name: app.name, path: path): [frameworkDependencies[0]],
+            frameworkDependencies[frameworkCount - 1]: [],
+        ]
+        for index in 0 ..< frameworkCount - 1 {
+            dependencies[frameworkDependencies[index]] = [frameworkDependencies[index + 1]]
+        }
+
+        let subject = GraphTraverser(
+            graph: .test(
+                path: path,
+                projects: [path: project],
+                targets: [
+                    path: Dictionary(uniqueKeysWithValues: targets.map { ($0.name, $0) }),
+                ],
+                dependencies: dependencies
+            )
+        )
+
+        // When
+        let result = try subject.linkableDependencies(path: path, name: app.name)
+
+        // Then
+        XCTAssertEqual(
+            result,
+            [
+                .product(
+                    target: frameworks[0].name,
+                    productName: frameworks[0].productNameWithExtension
+                ),
+            ]
+        )
+    }
+
     func test_linkableDependencies_transitiveDynamicLibrariesOneStaticHop() throws {
         // Given
         let staticFramework = Target.test(

--- a/Tests/GekoGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
+++ b/Tests/GekoGeneratorTests/Linter/StaticProductsGraphLinterTests.swift
@@ -1130,6 +1130,55 @@ class StaticProductsGraphLinterTests: XCTestCase {
         XCTAssertEqual(results, [])
     }
 
+    func test_lint_whenLongDependencyChainDoesNotRecurse() {
+        // Given
+        let path: AbsolutePath = "/project"
+        let frameworkCount = 20_000
+        let app = Target.test(name: "App")
+        let frameworks = (0 ..< frameworkCount).map {
+            Target.test(name: "Framework\($0)", product: .framework)
+        }
+        let staticFramework = Target.test(name: "StaticFramework", product: .staticFramework)
+        let targets = [app] + frameworks + [staticFramework]
+        let project = Project.test(path: path, targets: targets)
+
+        let appDependency = GraphDependency.target(name: app.name, path: path)
+        let frameworkDependencies = frameworks.map {
+            GraphDependency.target(name: $0.name, path: path)
+        }
+        let staticFrameworkDependency = GraphDependency.target(name: staticFramework.name, path: path)
+
+        var dependencies: [GraphDependency: Set<GraphDependency>] = [
+            appDependency: [frameworkDependencies[0]],
+            staticFrameworkDependency: [],
+        ]
+        for index in 0 ..< frameworkCount {
+            dependencies[frameworkDependencies[index]] = [
+                index + 1 < frameworkCount
+                    ? frameworkDependencies[index + 1]
+                    : staticFrameworkDependency,
+            ]
+        }
+
+        let graph = Graph.test(
+            path: path,
+            projects: [path: project],
+            targets: [
+                path: Dictionary(uniqueKeysWithValues: targets.map { ($0.name, $0) }),
+            ],
+            dependencies: dependencies
+        )
+
+        // When
+        let results = subject.lint(
+            graphTraverser: GraphTraverser(graph: graph),
+            config: .test()
+        )
+
+        // Then
+        XCTAssertEqual(results, [])
+    }
+
     // MARK: - Helpers
 
     private func warning(product node: String, type: String = "Target", linkedBy: [GraphDependency]) -> LintingIssue {

--- a/Tests/GekoGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/Tests/GekoGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -751,9 +751,16 @@ final class ModuleMapMapperTests: GekoUnitTestCase {
         // Given
         let projectPath = try temporaryPath()
         let nodeCount = 20_000
+        let leafModuleMapPath = projectPath.appending(component: "Leaf.modulemap")
         let targets = (0 ..< nodeCount).map { index in
             Target.test(
                 name: "Target\(index)",
+                settings: index == nodeCount - 1
+                    ? .test(base: [
+                        "MODULEMAP_FILE": .string(leafModuleMapPath.pathString),
+                        "HEADER_SEARCH_PATHS": .array(["$(SRCROOT)/Leaf/include"]),
+                    ])
+                    : .test(),
                 dependencies: index + 1 < nodeCount
                     ? [.target(name: "Target\(index + 1)")]
                     : []
@@ -762,7 +769,8 @@ final class ModuleMapMapperTests: GekoUnitTestCase {
         let project = Project.test(
             path: projectPath,
             name: "Project",
-            targets: targets
+            targets: targets,
+            projectType: .spm
         )
         var graph = Graph.test(
             projects: [projectPath: project],
@@ -779,5 +787,20 @@ final class ModuleMapMapperTests: GekoUnitTestCase {
 
         // Then
         XCTAssertEqual(sideEffects, [])
+        let rootSettings = try XCTUnwrap(
+            graph.targets[projectPath]?[targets[0].name]?.settings?.base
+        )
+        XCTAssertEqual(
+            rootSettings["OTHER_CFLAGS"],
+            .array(["$(inherited)", "-fmodule-map-file=$(SRCROOT)/Leaf.modulemap"])
+        )
+        XCTAssertEqual(
+            rootSettings["OTHER_SWIFT_FLAGS"],
+            .array(["$(inherited)", "-Xcc", "-fmodule-map-file=$(SRCROOT)/Leaf.modulemap"])
+        )
+        XCTAssertEqual(
+            rootSettings["HEADER_SEARCH_PATHS"],
+            .array(["$(inherited)", "$(SRCROOT)/Leaf/include"])
+        )
     }
 }

--- a/Tests/GekoGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
+++ b/Tests/GekoGeneratorTests/ProjectMappers/ModuleMapMapperTests.swift
@@ -746,4 +746,38 @@ final class ModuleMapMapperTests: GekoUnitTestCase {
         XCTAssertEqual(gotSideEffects, [])
         
     }
+
+    func test_maps_longDependencyChainWithoutRecursion() async throws {
+        // Given
+        let projectPath = try temporaryPath()
+        let nodeCount = 20_000
+        let targets = (0 ..< nodeCount).map { index in
+            Target.test(
+                name: "Target\(index)",
+                dependencies: index + 1 < nodeCount
+                    ? [.target(name: "Target\(index + 1)")]
+                    : []
+            )
+        }
+        let project = Project.test(
+            path: projectPath,
+            name: "Project",
+            targets: targets
+        )
+        var graph = Graph.test(
+            projects: [projectPath: project],
+            targets: [
+                projectPath: Dictionary(
+                    uniqueKeysWithValues: targets.map { ($0.name, $0) }
+                ),
+            ]
+        )
+        var sideTable = GraphSideTable()
+
+        // When
+        let sideEffects = try await subject.map(graph: &graph, sideTable: &sideTable)
+
+        // Then
+        XCTAssertEqual(sideEffects, [])
+    }
 }

--- a/Tests/GekoSupportTests/GraphAlgorithmsTests.swift
+++ b/Tests/GekoSupportTests/GraphAlgorithmsTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import GekoSupport
+
+final class GraphAlgorithmsTests: XCTestCase {
+    func test_topologicalSort_returnsReversePostorder() throws {
+        let graph = [
+            "A": ["B", "C"],
+            "B": ["D"],
+            "C": ["D"],
+            "D": [],
+        ]
+
+        let result = try topologicalSort(["A"]) { graph[$0] ?? [] }
+
+        XCTAssertEqual(result, ["A", "C", "B", "D"])
+    }
+
+    func test_topologicalSort_ignoresAlreadyVisitedRoots() throws {
+        let graph = [
+            "A": ["B"],
+            "B": [],
+        ]
+
+        let result = try topologicalSort(["A", "B", "A"]) { graph[$0] ?? [] }
+
+        XCTAssertEqual(result, ["A", "B"])
+    }
+
+    func test_topologicalSort_throwsWhenCycleIsDetected() {
+        let graph = [
+            "A": ["B"],
+            "B": ["C"],
+            "C": ["A"],
+        ]
+
+        XCTAssertThrowsError(try topologicalSort(["A"]) { graph[$0] ?? [] }) { error in
+            guard
+                let graphError = error as? GraphError,
+                case .unexpectedCycle = graphError
+            else {
+                return XCTFail("Expected GraphError.unexpectedCycle, got \(error)")
+            }
+        }
+    }
+
+    func test_topologicalSort_handlesLongChainsWithoutRecursion() throws {
+        let nodeCount = 20_000
+
+        let result = try topologicalSort([0]) { node in
+            node + 1 < nodeCount ? [node + 1] : []
+        }
+
+        XCTAssertEqual(result.count, nodeCount)
+        XCTAssertEqual(result.first, 0)
+        XCTAssertEqual(result.last, nodeCount - 1)
+    }
+
+    func test_findCycle_returnsPathAndCycle() {
+        let graph = [
+            "A": ["B"],
+            "B": ["C"],
+            "C": ["B"],
+        ]
+
+        let result = findCycle(["A"]) { graph[$0] ?? [] }
+
+        XCTAssertEqual(result?.path, ["A"])
+        XCTAssertEqual(result?.cycle, ["B", "C"])
+    }
+
+    func test_findCycle_handlesLongAcyclicChainsWithoutRecursion() {
+        let nodeCount = 20_000
+
+        let result = findCycle([0]) { node in
+            node + 1 < nodeCount ? [node + 1] : []
+        }
+
+        XCTAssertNil(result)
+    }
+}

--- a/Tests/GekoSupportTests/GraphAlgorithmsTests.swift
+++ b/Tests/GekoSupportTests/GraphAlgorithmsTests.swift
@@ -78,4 +78,17 @@ final class GraphAlgorithmsTests: XCTestCase {
 
         XCTAssertNil(result)
     }
+
+    func test_findCycle_handlesLongCyclicChainsWithoutRecursion() {
+        let nodeCount = 20_000
+
+        let result = findCycle([0]) { node in
+            node + 1 < nodeCount ? [node + 1] : [0]
+        }
+
+        let expectedCycle = (0 ..< nodeCount).map { $0 }
+
+        XCTAssertTrue(result?.path == [])
+        XCTAssertTrue(result?.cycle == expectedCycle)
+    }
 }


### PR DESCRIPTION
## Description

Large valid Geko dependency graphs can crash `geko generate` with a stack overflow when graph processing code uses recursive traversal.

This PR replaces the affected recursive traversals with iterative implementations that use explicit stacks:

- `topologicalSort` and `findCycle` in `GekoSupport`
- target dependency, resource bundle, searchable path, linkable dependency, Swift macro, platform condition, and supported-platform traversals in `GraphTraverser`
- `ModuleMapMapper`
- `StaticProductsGraphLinter`
- XCFramework dependency traversal in `SwiftModulesBuilder`

The implementations preserve the existing traversal semantics, ordering, caching, collected metadata, and diagnostics where relevant, without growing the Swift call stack for every visited graph node.

The local `topologicalSort` replaces the implementation imported from TSC. Its upstream source ([swiftlang/swift-tools-support-core](https://github.com/swiftlang/swift-tools-support-core)) is deprecated, so fixing it there would not be useful for Geko.

## Related Issue

This is the Geko counterpart of [tuist/tuist#11350](https://github.com/tuist/tuist/pull/11350), which fixes the same class of recursive graph traversal problems in Tuist.

Geko had already made its circular dependency linter stack-safe in [geko-tech/geko#92](https://github.com/geko-tech/geko/pull/92), and it does not contain Tuist's `GraphCircularDetector`, so those parts of the Tuist change did not need to be ported.

## Motivation and Context

We encountered this problem in our project while using Tuist. Removing a single dependency edge unexpectedly changed the graph traversal shape enough to produce a very deep valid acyclic graph, after which project generation started crashing with a stack overflow.

We are also evaluating and integrating Geko, which contains several of the same recursive graph-processing paths. Preventing the same failure mode here makes that integration safer for our large workspace and protects other sufficiently deep Geko projects from depending on the process call-stack limit.

Replacing recursion with explicit traversal stacks makes the affected code stack-safe without requiring changes to an otherwise valid dependency graph. During validation of the initial Geko changes, fixing one set of recursive paths exposed another stack overflow in Swift macro traversal, demonstrating how a deep graph can reach these risks one processing stage at a time.

## How Has This Been Tested?

### Automated tests

The following affected test suites were run:

```bash
swift test --filter GraphAlgorithmsTests
swift test --filter GraphTraverserTests
swift test --filter ModuleMapMapperTests
swift test --filter StaticProductsGraphLinterTests
swift test --filter SwiftModulesBuilderTests
```

Results:

- `GraphAlgorithmsTests`: 6 passed
- `GraphTraverserTests`: 137 passed
- `ModuleMapMapperTests`: 5 passed
- `StaticProductsGraphLinterTests`: 24 passed
- `SwiftModulesBuilderTests`: 2 passed
- Total: 174 tests passed with no failures

Test environment:

- macOS 26.5.2
- Apple Silicon (`arm64`)
- Swift 6.2.4

The new long-chain tests exercise graph depths that previously risked overflowing the process stack. Smaller characterization tests verify that the iterative implementations preserve relevant results such as traversal order, transitive dependencies, metadata, conditions, platform propagation, caching behavior, and lint warnings.

### End-to-end validation

I adapted the standalone fixture generator used for the related Tuist fix so that it can generate and validate the same large dependency graph using Geko manifests:

[igooor-bb/tuist-large-dag-repro](https://github.com/igooor-bb/tuist-large-dag-repro)

The fixture generates a large valid DAG that is intentionally closer to a real large workspace than a single linked list: multiple projects, feature layers, shared infrastructure, bridge targets with high fan-in, and no dependency cycles.

Primary Geko validation command:

```bash
GEKO_BIN=/path/to/geko ./scripts/reproduce.sh stress --tool geko --no-focus
```

Focused-target validation path:

```bash
GEKO_BIN=/path/to/geko ./scripts/reproduce.sh stress --tool geko --focus
```

For more details about the fixture structure, available presets, and reproduction commands, see the fixture repository README.

Actual result:

- the stress fixture is generated and validated successfully;
- the patched `geko generate` completes successfully on the generated workspace;
- no stack overflow occurs in the affected graph-processing paths.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.